### PR TITLE
Update mcp-proxy to only enable capabilities that are exported by the server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ build-backend = "setuptools.build_meta"
 [project.scripts]
 mcp-proxy = "mcp_proxy.__main__:main"
 
+[tool.uv]
+dev-dependencies = [
+    "pytest>=8.3.3",
+    "pytest-asyncio>=0.25.0",
+]
+
 [tool.pytest.ini_options]
 pythonpath = "src"
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,11 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 mcp-proxy = "mcp_proxy.__main__:main"
+
+[tool.pytest.ini_options]
+pythonpath = "src"
+addopts = [
+    "--import-mode=importlib",
+]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/src/mcp_proxy/__init__.py
+++ b/src/mcp_proxy/__init__.py
@@ -7,79 +7,89 @@ from mcp.client.session import ClientSession
 logger = logging.getLogger(__name__)
 
 
-async def create_server(name: str, remote_app: ClientSession):
-    app = server.Server(name)
+async def create_proxy_server(remote_app: ClientSession):
+    """Create a server instance from a remote app."""
 
-    async def _list_prompts(_: t.Any) -> types.ServerResult:
-        result = await remote_app.list_prompts()
-        return types.ServerResult(result)
+    response = await remote_app.initialize()
+    capabilities = response.capabilities
 
-    app.request_handlers[types.ListPromptsRequest] = _list_prompts
+    app = server.Server(response.serverInfo.name)
 
-    async def _get_prompt(req: types.GetPromptRequest) -> types.ServerResult:
-        result = await remote_app.get_prompt(req.params.name, req.params.arguments)
-        return types.ServerResult(result)
-
-    app.request_handlers[types.GetPromptRequest] = _get_prompt
-
-    async def _list_resources(_: t.Any) -> types.ServerResult:
-        result = await remote_app.list_resources()
-        return types.ServerResult(result)
-
-    app.request_handlers[types.ListResourcesRequest] = _list_resources
-
-    # list_resource_templates() is not implemented in the client
-    # async def _list_resource_templates(_: t.Any) -> types.ServerResult:
-    #     result = await remote_app.list_resource_templates()
-    #     return types.ServerResult(result)
-
-    # app.request_handlers[types.ListResourceTemplatesRequest] = _list_resource_templates
-
-    async def _read_resource(req: types.ReadResourceRequest):
-        result = await remote_app.read_resource(req.params.uri)
-        return types.ServerResult(result)
-
-    app.request_handlers[types.ReadResourceRequest] = _read_resource
-
-    async def _set_logging_level(req: types.SetLevelRequest):
-        await remote_app.set_logging_level(req.params.level)
-        return types.ServerResult(types.EmptyResult())
-
-    app.request_handlers[types.SetLevelRequest] = _set_logging_level
-
-    async def _subscribe_resource(req: types.SubscribeRequest):
-        await remote_app.subscribe_resource(req.params.uri)
-        return types.ServerResult(types.EmptyResult())
-
-    app.request_handlers[types.SubscribeRequest] = _subscribe_resource
-
-    async def _unsubscribe_resource(req: types.UnsubscribeRequest):
-        await remote_app.unsubscribe_resource(req.params.uri)
-        return types.ServerResult(types.EmptyResult())
-
-    app.request_handlers[types.UnsubscribeRequest] = _unsubscribe_resource
-
-    async def _list_tools(_: t.Any):
-        tools = await remote_app.list_tools()
-        return types.ServerResult(tools)
-
-    app.request_handlers[types.ListToolsRequest] = _list_tools
-
-    async def _call_tool(req: types.CallToolRequest) -> types.ServerResult:
-        try:
-            result = await remote_app.call_tool(
-                req.params.name, (req.params.arguments or {})
-            )
+    if capabilities.prompts:
+        async def _list_prompts(_: t.Any) -> types.ServerResult:
+            result = await remote_app.list_prompts()
             return types.ServerResult(result)
-        except Exception as e:
-            return types.ServerResult(
-                types.CallToolResult(
-                    content=[types.TextContent(type="text", text=str(e))],
-                    isError=True,
-                )
-            )
 
-    app.request_handlers[types.CallToolRequest] = _call_tool
+        app.request_handlers[types.ListPromptsRequest] = _list_prompts
+
+        async def _get_prompt(req: types.GetPromptRequest) -> types.ServerResult:
+            result = await remote_app.get_prompt(req.params.name, req.params.arguments)
+            return types.ServerResult(result)
+
+        app.request_handlers[types.GetPromptRequest] = _get_prompt
+
+    if capabilities.resources:
+        async def _list_resources(_: t.Any) -> types.ServerResult:
+            result = await remote_app.list_resources()
+            return types.ServerResult(result)
+
+        app.request_handlers[types.ListResourcesRequest] = _list_resources
+
+        # list_resource_templates() is not implemented in the client
+        # async def _list_resource_templates(_: t.Any) -> types.ServerResult:
+        #     result = await remote_app.list_resource_templates()
+        #     return types.ServerResult(result)
+
+        # app.request_handlers[types.ListResourceTemplatesRequest] = _list_resource_templates
+
+        async def _read_resource(req: types.ReadResourceRequest):
+            result = await remote_app.read_resource(req.params.uri)
+            return types.ServerResult(result)
+
+        app.request_handlers[types.ReadResourceRequest] = _read_resource
+
+    if capabilities.logging:
+        async def _set_logging_level(req: types.SetLevelRequest):
+            await remote_app.set_logging_level(req.params.level)
+            return types.ServerResult(types.EmptyResult())
+
+        app.request_handlers[types.SetLevelRequest] = _set_logging_level
+
+    if capabilities.resources:
+        async def _subscribe_resource(req: types.SubscribeRequest):
+            await remote_app.subscribe_resource(req.params.uri)
+            return types.ServerResult(types.EmptyResult())
+
+        app.request_handlers[types.SubscribeRequest] = _subscribe_resource
+
+        async def _unsubscribe_resource(req: types.UnsubscribeRequest):
+            await remote_app.unsubscribe_resource(req.params.uri)
+            return types.ServerResult(types.EmptyResult())
+
+        app.request_handlers[types.UnsubscribeRequest] = _unsubscribe_resource
+
+    if capabilities.tools:
+        async def _list_tools(_: t.Any):
+            tools = await remote_app.list_tools()
+            return types.ServerResult(tools)
+
+        app.request_handlers[types.ListToolsRequest] = _list_tools
+
+        async def _call_tool(req: types.CallToolRequest) -> types.ServerResult:
+            try:
+                result = await remote_app.call_tool(
+                    req.params.name, (req.params.arguments or {})
+                )
+                return types.ServerResult(result)
+            except Exception as e:
+                return types.ServerResult(
+                    types.CallToolResult(
+                        content=[types.TextContent(type="text", text=str(e))],
+                        isError=True,
+                    )
+                )
+
+        app.request_handlers[types.CallToolRequest] = _call_tool
 
     async def _send_progress_notification(req: types.ProgressNotification):
         await remote_app.send_progress_notification(
@@ -99,21 +109,15 @@ async def create_server(name: str, remote_app: ClientSession):
     return app
 
 
-async def configure_app(name: str, remote_app: ClientSession):
-    app = await create_server(name, remote_app)
-    async with server.stdio_server() as (read_stream, write_stream):
-        await app.run(
-            read_stream,
-            write_stream,
-            app.create_initialization_options(),
-        )
-
-
 async def run_sse_client(url: str):
     from mcp.client.sse import sse_client
 
     async with sse_client(url=url) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
-            response = await session.initialize()
-
-            await configure_app(response.serverInfo.name, session)
+            app = await create_proxy_server(session)
+            async with server.stdio_server() as (read_stream, write_stream):
+                await app.run(
+                    read_stream,
+                    write_stream,
+                    app.create_initialization_options(),
+                )

--- a/src/mcp_proxy/__init__.py
+++ b/src/mcp_proxy/__init__.py
@@ -7,7 +7,7 @@ from mcp.client.session import ClientSession
 logger = logging.getLogger(__name__)
 
 
-async def confugure_app(name: str, remote_app: ClientSession):
+async def create_server(name: str, remote_app: ClientSession):
     app = server.Server(name)
 
     async def _list_prompts(_: t.Any) -> types.ServerResult:
@@ -96,6 +96,11 @@ async def confugure_app(name: str, remote_app: ClientSession):
 
     app.request_handlers[types.CompleteRequest] = _complete
 
+    return app
+
+
+async def configure_app(name: str, remote_app: ClientSession):
+    app = await create_server(name, remote_app)
     async with server.stdio_server() as (read_stream, write_stream):
         await app.run(
             read_stream,
@@ -111,4 +116,4 @@ async def run_sse_client(url: str):
         async with ClientSession(read_stream, write_stream) as session:
             response = await session.initialize()
 
-            await confugure_app(response.serverInfo.name, session)
+            await configure_app(response.serverInfo.name, session)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for mcp-proxy."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,81 @@
+"""Tests for the mcp-proxy module."""
+
+import pytest
+import anyio
+from mcp import types
+from mcp.client.session import ClientSession
+from mcp.server import Server
+from mcp.shared.exceptions import McpError
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.server.stdio import stdio_server   
+
+from mcp_proxy import configure_app, create_server
+
+async def run_server() -> None:
+    """Run a stdio server."""
+
+    server = Server("test")
+
+    @server.list_prompts()
+    async def handle_list_prompts() -> list[types.Prompt]:
+        return [
+            types.Prompt(name="prompt1"),
+        ]
+    
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+async def test_list_prompts():
+    """Test list_prompts."""
+
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[
+        types.JSONRPCMessage
+    ](1)
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[
+        types.JSONRPCMessage
+    ](1)
+
+    server = Server("test")
+
+    @server.list_prompts()
+    async def list_prompts() -> list[types.Prompt]:
+        return [
+            types.Prompt(name="prompt1"),
+        ]
+    
+    async def run_server() -> None:
+        print("running server")
+        await server.run(client_to_server_receive, server_to_client_send, server.create_initialization_options())
+
+    async def listen_session():
+        print("listening session")
+        print(session)
+        async for message in session.incoming_messages:
+            if isinstance(message, Exception):
+                raise message
+            print("message")
+            print(message)
+
+    # Create an in memory connection to the fake server
+    async with create_connected_server_and_client_session(server) as session:
+
+        # Baseline behavior for client
+        result = await session.list_prompts()
+        assert result.prompts == [types.Prompt(name="prompt1")]
+
+        with pytest.raises(McpError, match="Method not found"):
+            await session.list_tools()
+
+        # Create a proxy instance to the in memory server
+        wrapped_server = await create_server("name", session)
+
+        # Create a client to the proxy server
+        async with create_connected_server_and_client_session(server) as wrapped_session:
+            await wrapped_session.initialize()
+
+            result = await wrapped_session.list_prompts()
+            assert result.prompts == [types.Prompt(name="prompt1")]
+
+            with pytest.raises(McpError, match="Method not found"):
+                await wrapped_session.list_tools()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,81 +1,109 @@
-"""Tests for the mcp-proxy module."""
+"""Tests for the mcp-proxy module.
+
+Tests are running in two modes:
+- One where the server is exercised directly though an in memory client, just to
+  set a baseline for the expected behavior.
+- Another where the server is exercised through a proxy server, which forwards
+  the requests to the original server.
+
+The same test code is run on both to ensure parity.
+"""
+
+from typing import Any
+from collections.abc import AsyncGenerator, Callable
+from contextlib import asynccontextmanager, AbstractAsyncContextManager
 
 import pytest
-import anyio
+
 from mcp import types
 from mcp.client.session import ClientSession
 from mcp.server import Server
 from mcp.shared.exceptions import McpError
 from mcp.shared.memory import create_connected_server_and_client_session
-from mcp.server.stdio import stdio_server   
 
-from mcp_proxy import configure_app, create_server
+from mcp_proxy import create_proxy_server
 
-async def run_server() -> None:
-    """Run a stdio server."""
+TOOL_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "input1": {"type": "string"}
+    }
+}
 
-    server = Server("test")
+SessionContextManager = Callable[[Server], AbstractAsyncContextManager[ClientSession]]
 
-    @server.list_prompts()
-    async def handle_list_prompts() -> list[types.Prompt]:
-        return [
-            types.Prompt(name="prompt1"),
-        ]
-    
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, server.create_initialization_options())
+# Direct server connection
+in_memory: SessionContextManager  = create_connected_server_and_client_session
+
+@asynccontextmanager
+async def proxy(server: Server) -> AsyncGenerator[ClientSession, None]:
+    """Create a connection to the server through the proxy server."""
+    async with in_memory(server) as session:
+        wrapped_server = await create_proxy_server(session)
+        async with in_memory(wrapped_server) as wrapped_session:
+            yield wrapped_session
 
 
-async def test_list_prompts():
+@pytest.fixture(params=["server", "proxy"], scope="function")
+def session_generator(request: Any) -> SessionContextManager:
+    """Fixture that returns a client creation strategy either direct or using the proxy."""
+    if request.param == "server":
+        return in_memory
+    return proxy
+
+
+async def test_list_prompts(session_generator: SessionContextManager):
     """Test list_prompts."""
 
-    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[
-        types.JSONRPCMessage
-    ](1)
-    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[
-        types.JSONRPCMessage
-    ](1)
-
-    server = Server("test")
+    server = Server("prompt-server")
 
     @server.list_prompts()
     async def list_prompts() -> list[types.Prompt]:
-        return [
-            types.Prompt(name="prompt1"),
-        ]
-    
-    async def run_server() -> None:
-        print("running server")
-        await server.run(client_to_server_receive, server_to_client_send, server.create_initialization_options())
+        return [types.Prompt(name="prompt1")]
 
-    async def listen_session():
-        print("listening session")
-        print(session)
-        async for message in session.incoming_messages:
-            if isinstance(message, Exception):
-                raise message
-            print("message")
-            print(message)
+    async with session_generator(server) as session:
+        result = await session.initialize()
+        assert result.serverInfo.name == "prompt-server"
+        assert result.capabilities
+        assert result.capabilities.prompts
+        assert not result.capabilities.tools
+        assert not result.capabilities.resources
+        assert not result.capabilities.logging
 
-    # Create an in memory connection to the fake server
-    async with create_connected_server_and_client_session(server) as session:
-
-        # Baseline behavior for client
         result = await session.list_prompts()
         assert result.prompts == [types.Prompt(name="prompt1")]
 
         with pytest.raises(McpError, match="Method not found"):
             await session.list_tools()
 
-        # Create a proxy instance to the in memory server
-        wrapped_server = await create_server("name", session)
 
-        # Create a client to the proxy server
-        async with create_connected_server_and_client_session(server) as wrapped_session:
-            await wrapped_session.initialize()
+async def test_list_tools(session_generator: SessionContextManager):
+    """Test list_tools."""
 
-            result = await wrapped_session.list_prompts()
-            assert result.prompts == [types.Prompt(name="prompt1")]
+    server = Server("tools-server")
 
-            with pytest.raises(McpError, match="Method not found"):
-                await wrapped_session.list_tools()
+    @server.list_tools()
+    async def list_tools() -> list[types.Tool]:
+        return [types.Tool(
+            name="tool-name",
+            description="tool-description",
+            inputSchema=TOOL_INPUT_SCHEMA
+        )]
+
+    async with session_generator(server) as session:
+        result = await session.initialize()
+        assert result.serverInfo.name == "tools-server"
+        assert result.capabilities
+        assert result.capabilities.tools
+        assert not result.capabilities.prompts
+        assert not result.capabilities.resources
+        assert not result.capabilities.logging
+
+        result = await session.list_tools()
+        assert len(result.tools) == 1
+        assert result.tools[0].name == "tool-name"
+        assert result.tools[0].description == "tool-description"
+        assert result.tools[0].inputSchema == TOOL_INPUT_SCHEMA
+
+        with pytest.raises(McpError, match="Method not found"):
+            await session.list_prompts()

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -89,6 +98,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
 name = "mcp"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -113,8 +131,38 @@ dependencies = [
     { name = "mcp" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "mcp" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
 
 [[package]]
 name = "pydantic"
@@ -181,6 +229,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
     { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
     { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/18/82fcb4ee47d66d99f6cd1efc0b11b2a25029f303c599a5afda7c1bca4254/pytest_asyncio-0.25.0.tar.gz", hash = "sha256:8c0610303c9e0442a5db8604505fc0f545456ba1528824842b37b4a626cbf609", size = 53298 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/56/2ee0cab25c11d4e38738a2a98c645a8f002e2ecf7b5ed774c70d53b92bb1/pytest_asyncio-0.25.0-py3-none-any.whl", hash = "sha256:db5432d18eac6b7e28b46dcd9b69921b55c3b1086e85febfe04e70b18d9e81b3", size = 19245 },
 ]
 
 [[package]]


### PR DESCRIPTION
This fixes an issue where clients attempt to call capabilities that do not exist and get stuck. Adds test coverage that exercises a fake server and the same fake server through the proxy to ensure the behavior is the same on both.