### PR TITLE
Add support for specifying authentication tokens in mcp-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,19 @@ Configure Claude Desktop to recognize the MCP server.
         "mcp-proxy": {
             "command": "mcp-proxy",
             "env": {
-                "SSE_URL": "http://example.io/sss"
+              "SSE_URL": "http://example.io/sse"
             }
-          }
         }
       }
     }
 
     ```
+
+## Advanced Configuration
+
+### Environment Variables
+
+| Name | Description |
+| ---- | ----------- |
+| SSE_URL | The MCP server SSE endpoint to connect to e.g. http://example.io/sse |
+| API_ACCESS_TOKEN | Added in the `Authorization` header of the HTTP request as a `Bearer` access token |

--- a/src/mcp_proxy/__init__.py
+++ b/src/mcp_proxy/__init__.py
@@ -104,10 +104,14 @@ async def confugure_app(name: str, remote_app: ClientSession):
         )
 
 
-async def run_sse_client(url: str):
+async def run_sse_client(url: str, api_access_token: str | None = None):
     from mcp.client.sse import sse_client
 
-    async with sse_client(url=url) as (read_stream, write_stream):
+    headers = {}
+    if api_access_token is not None:
+        headers["Authorization"] = f"Bearer {api_access_token}"
+
+    async with sse_client(url=url, headers=headers) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             response = await session.initialize()
 

--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -7,13 +7,14 @@ from . import run_sse_client
 
 logging.basicConfig(level=logging.DEBUG)
 SSE_URL: t.Final[str] = os.getenv("SSE_URL", "")
+API_ACCESS_TOKEN: t.Final[str] = os.getenv("API_ACCESS_TOKEN", None)
 
 if not SSE_URL:
     raise ValueError("SSE_URL environment variable is not set")
 
 
 def main():
-    asyncio.run(run_sse_client(SSE_URL))
+    asyncio.run(run_sse_client(SSE_URL, api_access_token=API_ACCESS_TOKEN))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow users to set an environment variable `API_ACCESS_TOKEN` that will set an authorization header for the SSE server, allowing reuse of authentication at the HTTP level.

This is likely only needed temporarily until MCP defines an authentication standard which is in progress and on the roadmap.