### PR TITLE
fix ruff linting for docstring using numpy convention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "INP001"]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff]
 line-length = 100
 


### PR DESCRIPTION
You are using google docstring style over the codebase but it was somehow being picked up as numpy style from my ruff server causing linting error on the docstring. Setting the pydocstyle to google convention in the pyproject.toml fix this.