### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mcp-proxy
 
+[![smithery badge](https://smithery.ai/badge/mcp-proxy)](https://smithery.ai/server/mcp-proxy)
+
 - [mcp-proxy](#mcp-proxy)
   - [About](#about)
   - [Installation](#installation)
@@ -26,6 +28,14 @@ graph LR
 > As of now, Claude Desktop does not support MCP servers that run on SSE transport. This server is a workaround to enable the support.
 
 ## Installation
+
+### Installing via Smithery
+
+To install MCP Proxy for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-proxy):
+
+```bash
+npx -y @smithery/cli install mcp-proxy --client claude
+```
 
 The stable version of the package is available on the PyPI repository. You can install it using the following command:
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install MCP Proxy for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-proxy

Let me know if any tweaks have to be made!