### PR TITLE
feat: Allow passing through all environment variables to server

### DIFF
--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -77,6 +77,12 @@ def main() -> None:
         help="Environment variables used when spawning the server. Can be used multiple times.",
         default=[],
     )
+    stdio_client_options.add_argument(
+        "--pass-environment",
+        action=argparse.BooleanOptionalAction,
+        help="Pass through all environment variables when spawning the server.",
+        default=False,
+    )
 
     sse_server_group = parser.add_argument_group("SSE server options")
     sse_server_group.add_argument(
@@ -112,10 +118,13 @@ def main() -> None:
 
     # Start a client connected to the given command, and expose as an SSE server
     logging.debug("Starting stdio client and SSE server")
+    env = dict(args.env)
+    if args.pass_environment:
+        env.update(os.environ)
     stdio_params = StdioServerParameters(
         command=args.command_or_url,
         args=args.args,
-        env=dict(args.env),
+        env=env,
     )
     sse_settings = SseServerSettings(
         bind_host=args.sse_host,


### PR DESCRIPTION
This PR adds the ability to pass through all environment variables to the server, using the flag `--pass-environment` (default off).

This change allows a compose spec like this to access all environment variables from an env_file (as well as PATH):

```yaml
server-brave-search:
  image: mcp-proxy:latest
  env_file: .brave.env
  # ENTRYPOINT from custom SSE-only image, for context
  entrypoint: ["mcp-proxy", "--sse-host=0.0.0.0", "--sse-port=8080", "--pass-environment", "--"]
  command: ["npx", "--yes", "@modelcontextprotocol/server-brave-search"]
```

The motivation behind this is I am developing in Docker Compose, with a custom client and multiple servers. I made a debian-based mcp-proxy image, with an entrypoint that set some SSE settings. When it came to adding brave search, I spent a bit of time struggling against var interpolation and an overridden entrypoint (cause: you can't access env vars in entrypoints, I think). I figured passing through all environment variables would be easier (and safe in a container).

I started adding tests for this, but found myself refactoring \_\_main\_\_.py quite a bit to make it more testable. I've left that for now in the aim of an easy-to-review PR, but am happy to continue that effort if you'd like? Essentially breaking out the argument parser and the SSE client/server parts into functions and validating their config.

Thanks again for this tool - it's made adding support for stdio servers in our client much easier!