### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![codecov](https://codecov.io/gh/sparfenyuk/mcp-proxy/graph/badge.svg?token=31VV9L7AZQ)](https://codecov.io/gh/sparfenyuk/mcp-proxy)
 [![smithery badge](https://smithery.ai/badge/mcp-proxy)](https://smithery.ai/server/mcp-proxy)
 
+<a href="https://glama.ai/mcp/servers/@sparfenyuk/mcp-proxy">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sparfenyuk/mcp-proxy/badge" alt="Proxy Server MCP server" />
+</a>
+
 - [mcp-proxy](#mcp-proxy)
   - [About](#about)
   - [1. stdio to SSE](#1-stdio-to-sse)


### PR DESCRIPTION
This PR adds a badge for the [MCP Proxy Server](https://glama.ai/mcp/servers/@sparfenyuk/mcp-proxy) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sparfenyuk/mcp-proxy">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sparfenyuk/mcp-proxy/badge" alt="Proxy Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.