### PR TITLE
Add optional Authorization header token-based authentication when serving mcp via SSE

### DIFF
--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -108,7 +108,11 @@ def main() -> None:
         default=[],
         help="Allowed origins for the SSE server. Can be used multiple times. Default is no CORS allowed.",  # noqa: E501
     )
-
+    sse_server_group.add_argument(
+        "--auth-token",
+        default=None,
+        help="Authentication token for the SSE server. Default is no authentication.",
+    )
     args = parser.parse_args()
 
     if not args.command_or_url:
@@ -151,6 +155,7 @@ def main() -> None:
         bind_host=args.sse_host,
         port=args.sse_port,
         allow_origins=args.allow_origin if len(args.allow_origin) > 0 else None,
+        auth_token=args.auth_token,
         log_level="DEBUG" if args.debug else "INFO",
     )
     asyncio.run(run_sse_server(stdio_params, sse_settings))

--- a/src/mcp_proxy/sse_server.py
+++ b/src/mcp_proxy/sse_server.py
@@ -62,7 +62,7 @@ def create_starlette_app(
     auth_token: str | None = None,
     debug: bool = False,
 ) -> Starlette:
-    """Create a Starlette application with optional authentication."""
+    """Create a Starlette application that can serve the provided mcp server with optional authentication."""
     sse = SseServerTransport("/messages/")
 
     async def handle_sse(request: Request) -> None:

--- a/src/mcp_proxy/sse_server.py
+++ b/src/mcp_proxy/sse_server.py
@@ -28,7 +28,6 @@ class HeaderAuthBackend(AuthenticationBackend):
     """Authentication backend to authenticate requests based on Authorization header."""
     def __init__(self, auth_token: str):
         self.auth_token = auth_token
-        logger.debug("Using authentication token: %s", auth_token)
 
     async def authenticate(self, conn):
         if "Authorization" not in conn.headers:
@@ -66,10 +65,6 @@ def create_starlette_app(
     sse = SseServerTransport("/messages/")
 
     async def handle_sse(request: Request) -> None:
-        # if request.user.is_authenticated:
-        print("auth_token: ", auth_token)
-        print(request.__dict__)
-        # logger.debug(request)
         async with sse.connect_sse(
             request.scope,
             request.receive,

--- a/src/mcp_proxy/sse_server.py
+++ b/src/mcp_proxy/sse_server.py
@@ -13,7 +13,7 @@ from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.authentication import AuthenticationMiddleware
-from starlette.requests import Request
+from starlette.requests import Request, HTTPConnection
 from starlette.routing import Mount, Route
 
 from .proxy_server import create_proxy_server
@@ -29,7 +29,7 @@ class HeaderAuthBackend(AuthenticationBackend):
     def __init__(self, auth_token: str):
         self.auth_token = auth_token
 
-    async def authenticate(self, conn):
+    async def authenticate(self, conn: HTTPConnection) -> tuple[AuthCredentials, SimpleUser]:
         if "Authorization" not in conn.headers:
             raise AuthenticationError('Invalid token')
         


### PR DESCRIPTION
Add an optional AuthenticationMiddleware backend that can check for an Authorization header value from clients connecting when serving an mcp server via SSE.