### PR TITLE
README updates on --env

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,18 @@ separator.
 
 Arguments
 
-| Name                      | Required                   | Description                                                                                 | Example               |
-|---------------------------|----------------------------|---------------------------------------------------------------------------------------------|-----------------------|
-| `command_or_url`          | Yes                        | The command to spawn the MCP stdio server                                                   | uvx mcp-server-fetch  |
-| `--port`                  | No, random available       | The MCP server port to listen on                                                            | 8080                  |
-| `--host`                  | No, `127.0.0.1` by default | The host IP address that the MCP server will listen on                                      | 0.0.0.0               |
-| `--env`                   | No                         | Additional environment variables to pass to the MCP stdio server                            | FOO=BAR               |
-| `--cwd`                   | No                         | The working directory to pass to the MCP stdio server process.                              | /tmp                  |
-| `--pass-environment`      | No                         | Pass through all environment variables when spawning the server                             | --no-pass-environment |
-| `--allow-origin`          | No                         | Allowed origins for the SSE server. Can be used multiple times. Default is no CORS allowed. | --allow-cors "\*"     |
-| `--stateless`             | No                         | Enable stateless mode for streamable http transports. Default is False                      | --no-stateless        |
-| `--sse-port` (deprecated) | No, random available       | The SSE server port to listen on                                                            | 8080                  |
-| `--sse-host` (deprecated) | No, `127.0.0.1` by default | The host IP address that the SSE server will listen on                                      | 0.0.0.0               |
+| Name                      | Required                   | Description                                                                                   | Example               |
+|---------------------------|----------------------------|-----------------------------------------------------------------------------------------------|-----------------------|
+| `command_or_url`          | Yes                        | The command to spawn the MCP stdio server                                                     | uvx mcp-server-fetch  |
+| `--port`                  | No, random available       | The MCP server port to listen on                                                              | 8080                  |
+| `--host`                  | No, `127.0.0.1` by default | The host IP address that the MCP server will listen on                                        | 0.0.0.0               |
+| `--env`                   | No                         | Additional environment variables to pass to the MCP stdio server. Can be used multiple times. | FOO BAR               |
+| `--cwd`                   | No                         | The working directory to pass to the MCP stdio server process.                                | /tmp                  |
+| `--pass-environment`      | No                         | Pass through all environment variables when spawning the server                               | --no-pass-environment |
+| `--allow-origin`          | No                         | Allowed origins for the SSE server. Can be used multiple times. Default is no CORS allowed.   | --allow-cors "\*"     |
+| `--stateless`             | No                         | Enable stateless mode for streamable http transports. Default is False                        | --no-stateless        |
+| `--sse-port` (deprecated) | No, random available       | The SSE server port to listen on                                                              | 8080                  |
+| `--sse-host` (deprecated) | No, `127.0.0.1` by default | The host IP address that the SSE server will listen on                                        | 0.0.0.0               |
 
 ### 2.2 Example usage
 


### PR DESCRIPTION
`--env` takes in `FOO BAR` and not `FOO=BAR`