### PR TITLE
[BUG] Fixed missing slash on SEE /messages path

### DIFF
--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -64,7 +64,7 @@ def create_single_instance_routes(
         stateless_instance,
     )
 
-    sse_transport = SseServerTransport("messages/")
+    sse_transport = SseServerTransport("/messages/")
     http_session_manager = StreamableHTTPSessionManager(
         app=mcp_server_instance,
         event_store=None,


### PR DESCRIPTION
When creating a server using `--named-server-config`, the corresponding server paths exposed using SSE are not including a slash between named server and messages path

## Steps to reproduce
Command
```
uv run mcp-proxy --transport sse --port=8080 --named-server-config ./servers.json
```

servers.json
```
{
  "mcpServers": {
    "fetch": {
      "disabled": false,
      "timeout": 60,
      "command": "uvx",
      "args": [
        "mcp-server-fetch"
      ],
      "transportType": "sse"
    },
    "github": {
      "timeout": 60,
      "command": "npx",
      "args": [
        "-y",
        "@modelcontextprotocol/server-github"
      ],
      "transportType": "sse"
    }
  }
}
```

When inspecting `/servers/github/sse/` you get the following error:
```
INFO:     127.0.0.1:40248 - "POST /servers/githubmessages/?session_id=82f1d2cab56b4e63b184d3a3f92ee1a5 HTTP/1.1" 404 Not Found
```