### PR TITLE
fix: disable redirect to trailing slashes

### DIFF
--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -185,6 +185,8 @@ async def run_mcp_server(
             lifespan=combined_lifespan,
         )
 
+        starlette_app.router.redirect_slashes = False
+
         config = uvicorn.Config(
             starlette_app,
             host=mcp_settings.bind_host,


### PR DESCRIPTION
Starlette's default behavior adds a trailing slash to every routes without it (https://github.com/encode/starlette/discussions/2548), e.g. when client initiates a request to `/mcp`, it returns a `307 Temporary Redirect` response to `/mcp/`. This is causing some annoying issues, especially in our internal environment where server instances sit behind a load balancer and do not have access to their actual domain name, Starlette returns the instance's internal ip which the client cannot recognize and access. This PR disables this behavior.