### PR TITLE
feat: disable SSL cert verification with --no-verify-ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,11 @@ services:
 ## Command line arguments
 
 ```bash
-usage: mcp-proxy [-h] [--version] [-H KEY VALUE] [--transport {sse,streamablehttp}]
-                 [-e KEY VALUE] [--cwd CWD]
-                 [--pass-environment | --no-pass-environment] [--log-level LEVEL] [--debug | --no-debug]
+usage: mcp-proxy [-h] [--version] [-H KEY VALUE]
+                 [--transport {sse,streamablehttp}] [--verify-ssl [VALUE]]
+                 [--no-verify-ssl] [-e KEY VALUE] [--cwd CWD]
+                 [--pass-environment | --no-pass-environment]
+                 [--log-level LEVEL] [--debug | --no-debug]
                  [--named-server NAME COMMAND_STRING]
                  [--named-server-config FILE_PATH] [--port PORT] [--host HOST]
                  [--stateless | --no-stateless] [--sse-port SSE_PORT]
@@ -329,6 +331,8 @@ SSE/StreamableHTTP client options:
                         Headers to pass to the SSE server. Can be used multiple times.
   --transport {sse,streamablehttp}
                         The transport to use for the client. Default is SSE.
+  --verify-ssl [VALUE]  Control SSL verification when acting as a client. Use without a value to force verification, pass 'false' to disable, or provide a path to a PEM bundle.
+  --no-verify-ssl       Disable SSL verification (alias for --verify-ssl false).
 
 stdio client options:
   args                  Any extra arguments to the command to spawn the default server. Ignored if only named servers are defined.
@@ -355,14 +359,13 @@ SSE server options:
 
 Examples:
   mcp-proxy http://localhost:8080/sse
+  mcp-proxy --no-verify-ssl https://server.local/sse
   mcp-proxy --transport streamablehttp http://localhost:8080/mcp
   mcp-proxy --headers Authorization 'Bearer YOUR_TOKEN' http://localhost:8080/sse
-  mcp-proxy --port 8080 -- my-default-command --arg1 value1
-  mcp-proxy --port 8080 --named-server fetch1 'uvx mcp-server-fetch' --named-server tool2 'my-custom-tool --verbose'
-  mcp-proxy --port 8080 --named-server-config /path/to/servers.json
-  mcp-proxy --port 8080 --named-server-config /path/to/servers.json -- my-default-command --arg1
-  mcp-proxy --port 8080 -e KEY VALUE -e ANOTHER_KEY ANOTHER_VALUE -- my-default-command
-  mcp-proxy --port 8080 --allow-origin='*' -- my-default-command
+  mcp-proxy --port 8080 -- your-command --arg1 value1 --arg2 value2
+  mcp-proxy --named-server fetch 'uvx mcp-server-fetch' --port 8080
+  mcp-proxy your-command --port 8080 -e KEY VALUE -e ANOTHER_KEY ANOTHER_VALUE
+  mcp-proxy your-command --port 8080 --allow-origin='*'
 ```
 
 ### Example config file

--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -30,6 +30,20 @@ SSE_URL: t.Final[str | None] = os.getenv(
 )
 
 
+def _normalize_verify_ssl(value: str | bool | None) -> bool | str | None:
+    """Normalize the verify_ssl argument into bool, str path, or None."""
+    if isinstance(value, bool) or value is None:
+        return value
+
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+
+    return value
+
+
 def _setup_argument_parser() -> argparse.ArgumentParser:
     """Set up and return the argument parser for the MCP proxy."""
     parser = argparse.ArgumentParser(
@@ -37,6 +51,7 @@ def _setup_argument_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  mcp-proxy http://localhost:8080/sse\n"
+            "  mcp-proxy --no-verify-ssl https://server.local/sse\n"
             "  mcp-proxy --transport streamablehttp http://localhost:8080/mcp\n"
             "  mcp-proxy --headers Authorization 'Bearer YOUR_TOKEN' http://localhost:8080/sse\n"
             "  mcp-proxy --port 8080 -- your-command --arg1 value1 --arg2 value2\n"
@@ -93,6 +108,25 @@ def _add_arguments_to_parser(parser: argparse.ArgumentParser) -> None:
         choices=["sse", "streamablehttp"],
         default="sse",  # For backwards compatibility
         help="The transport to use for the client. Default is SSE.",
+    )
+    client_group.add_argument(
+        "--verify-ssl",
+        nargs="?",
+        const=True,
+        default=None,
+        metavar="VALUE",
+        dest="verify_ssl",
+        help=(
+            "Control SSL verification when acting as a client. Use without a value to "
+            "force verification, pass 'false' to disable, or provide a path to a PEM bundle."
+        ),
+    )
+    client_group.add_argument(
+        "--no-verify-ssl",
+        dest="verify_ssl",
+        action="store_const",
+        const=False,
+        help=("Disable SSL verification (alias for --verify-ssl false)."),
     )
 
     stdio_client_options = parser.add_argument_group("stdio client options")
@@ -226,6 +260,7 @@ def _setup_logging(*, level: str, debug: bool) -> logging.Logger:
 def _handle_sse_client_mode(
     args_parsed: argparse.Namespace,
     logger: logging.Logger,
+    verify_ssl: bool | str | None = None,
 ) -> None:
     """Handle SSE/StreamableHTTP client mode operation."""
     if args_parsed.named_server_definitions:
@@ -240,9 +275,17 @@ def _handle_sse_client_mode(
         headers["Authorization"] = f"Bearer {api_access_token}"
 
     if args_parsed.transport == "streamablehttp":
-        asyncio.run(run_streamablehttp_client(args_parsed.command_or_url, headers=headers))
+        asyncio.run(
+            run_streamablehttp_client(
+                args_parsed.command_or_url,
+                headers=headers,
+                verify_ssl=verify_ssl,
+            ),
+        )
     else:
-        asyncio.run(run_sse_client(args_parsed.command_or_url, headers=headers))
+        asyncio.run(
+            run_sse_client(args_parsed.command_or_url, headers=headers, verify_ssl=verify_ssl),
+        )
 
 
 def _configure_default_server(
@@ -372,7 +415,8 @@ def main() -> None:
     if args_parsed.command_or_url and args_parsed.command_or_url.startswith(
         ("http://", "https://"),
     ):
-        _handle_sse_client_mode(args_parsed, logger)
+        verify_ssl = _normalize_verify_ssl(getattr(args_parsed, "verify_ssl", None))
+        _handle_sse_client_mode(args_parsed, logger, verify_ssl=verify_ssl)
         return
 
     # Start stdio client(s) and expose as an SSE server

--- a/src/mcp_proxy/httpx_client.py
+++ b/src/mcp_proxy/httpx_client.py
@@ -1,0 +1,122 @@
+"""HTTP request logging patch for MCP proxy.
+
+This module patches the create_mcp_http_client function to add comprehensive
+request and response logging capabilities.
+"""
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def custom_httpx_client(  # noqa: C901
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+    verify_ssl: bool | str | None = None,
+) -> httpx.AsyncClient:
+    """Create a standardized httpx AsyncClient with MCP defaults and logging.
+
+    This is a replacement for the original create_mcp_http_client that adds
+    comprehensive request/response logging capabilities.
+
+    Args:
+        headers: Optional headers to include with all requests.
+        timeout: Request timeout as httpx.Timeout object.
+        auth: Optional authentication handler.
+        verify_ssl: Control SSL verification. Use False to disable
+            or a path to a certificate bundle.
+
+    Returns:
+        Configured httpx.AsyncClient instance with MCP defaults and logging.
+    """
+    # Set MCP defaults (copied from original implementation)
+    kwargs: dict[str, Any] = {
+        "follow_redirects": True,
+    }
+
+    # Handle timeout
+    if timeout is None:
+        kwargs["timeout"] = httpx.Timeout(30.0)
+    else:
+        kwargs["timeout"] = timeout
+
+    # Handle headers
+    if headers is not None:
+        kwargs["headers"] = headers
+
+    # Handle authentication
+    if auth is not None:
+        kwargs["auth"] = auth
+
+    if verify_ssl is not None:
+        normalized_verify: bool | str
+        if isinstance(verify_ssl, str):
+            lowered = verify_ssl.strip().lower()
+            if lowered in {"1", "true", "yes", "on"}:
+                normalized_verify = True
+            elif lowered in {"0", "false", "no", "off"}:
+                normalized_verify = False
+            else:
+                normalized_verify = verify_ssl
+        else:
+            normalized_verify = verify_ssl
+
+        kwargs["verify"] = normalized_verify
+
+        if isinstance(normalized_verify, bool):
+            logger.debug(
+                "Configured httpx.AsyncClient verify=%s (SSL verification %s).",
+                normalized_verify,
+                "enabled" if normalized_verify else "disabled",
+            )
+        else:
+            logger.debug(
+                "Configured httpx.AsyncClient using certificate bundle at %s.",
+                normalized_verify,
+            )
+
+    # Add logging event hooks
+    async def log_request(request: httpx.Request) -> None:
+        """Log HTTP request details."""
+        logger.info(
+            "HTTP Request: %s %s",
+            request.method,
+            request.url,
+        )
+
+        # Log headers (be careful with sensitive data)
+        if logger.isEnabledFor(logging.DEBUG) or True:
+            safe_headers = {}
+            for key, value in request.headers.items():
+                # Mask sensitive headers
+                if key.lower() in ("authorization", "x-api-key", "cookie"):
+                    safe_headers[key] = "***MASKED***"
+                else:
+                    safe_headers[key] = value
+            logger.info("Request Headers: %s", safe_headers)
+
+    async def log_response(response: httpx.Response) -> None:
+        """Log HTTP response details."""
+        logger.debug(
+            "HTTP Response: %s %s - %d %s",
+            response.request.method,
+            response.request.url,
+            response.status_code,
+            response.reason_phrase,
+        )
+
+        # Log response headers
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Response Headers: %s", dict(response.headers))
+
+    # Add event hooks
+    kwargs["event_hooks"] = {
+        "request": [log_request],
+        "response": [log_response],
+    }
+
+    return httpx.AsyncClient(**kwargs)

--- a/src/mcp_proxy/sse_client.py
+++ b/src/mcp_proxy/sse_client.py
@@ -1,23 +1,37 @@
 """Create a local server that proxies requests to a remote server over SSE."""
 
+from functools import partial
 from typing import Any
 
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.server.stdio import stdio_server
 
+from .httpx_client import custom_httpx_client
 from .proxy_server import create_proxy_server
 
 
-async def run_sse_client(url: str, headers: dict[str, Any] | None = None) -> None:
+async def run_sse_client(
+    url: str,
+    headers: dict[str, Any] | None = None,
+    verify_ssl: bool | str | None = None,
+) -> None:
     """Run the SSE client.
 
     Args:
         url: The URL to connect to.
         headers: Headers for connecting to MCP server.
-
+        verify_ssl: Control SSL verification. Use False to disable
+            or a path to a certificate bundle.
     """
-    async with sse_client(url=url, headers=headers) as streams, ClientSession(*streams) as session:
+    async with (
+        sse_client(
+            url=url,
+            headers=headers,
+            httpx_client_factory=partial(custom_httpx_client, verify_ssl=verify_ssl),
+        ) as streams,
+        ClientSession(*streams) as session,
+    ):
         app = await create_proxy_server(session)
         async with stdio_server() as (read_stream, write_stream):
             await app.run(

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -1,24 +1,35 @@
 """Create a local server that proxies requests to a remote server over SSE."""
 
+from functools import partial
 from typing import Any
 
 from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.server.stdio import stdio_server
 
+from .httpx_client import custom_httpx_client
 from .proxy_server import create_proxy_server
 
 
-async def run_streamablehttp_client(url: str, headers: dict[str, Any] | None = None) -> None:
+async def run_streamablehttp_client(
+    url: str,
+    headers: dict[str, Any] | None = None,
+    verify_ssl: bool | str | None = None,
+) -> None:
     """Run the SSE client.
 
     Args:
         url: The URL to connect to.
         headers: Headers for connecting to MCP server.
-
+        verify_ssl: Control SSL verification. Use False to disable
+            or a path to a certificate bundle.
     """
     async with (
-        streamablehttp_client(url=url, headers=headers) as (read, write, _),
+        streamablehttp_client(
+            url=url,
+            headers=headers,
+            httpx_client_factory=partial(custom_httpx_client, verify_ssl=verify_ssl),
+        ) as (read, write, _),
         ClientSession(read, write) as session,
     ):
         app = await create_proxy_server(session)

--- a/tests/test_cli_arguments.py
+++ b/tests/test_cli_arguments.py
@@ -1,0 +1,61 @@
+"""Tests for CLI argument handling."""
+
+from __future__ import annotations
+
+import typing as t
+from unittest.mock import patch
+
+import pytest
+
+from mcp_proxy.__main__ import _normalize_verify_ssl, _setup_argument_parser
+from mcp_proxy.httpx_client import custom_httpx_client
+
+if t.TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+
+@pytest.fixture
+def parser() -> ArgumentParser:
+    """Return a fresh argument parser for each test."""
+    return _setup_argument_parser()
+
+
+def test_verify_ssl_cli_false(parser: ArgumentParser) -> None:
+    """Calling --verify-ssl false disables verification."""
+    args = parser.parse_args(["--verify-ssl", "false", "https://example.com"])
+    assert _normalize_verify_ssl(args.verify_ssl) is False
+
+
+def test_verify_ssl_cli_true(parser: ArgumentParser) -> None:
+    """Passing --verify-ssl true enforces verification."""
+    args = parser.parse_args(["--verify-ssl", "true", "https://example.com"])
+    assert _normalize_verify_ssl(args.verify_ssl) is True
+
+
+def test_verify_ssl_cli_cert_path(parser: ArgumentParser) -> None:
+    """Passing a certificate path keeps the string value."""
+    args = parser.parse_args(["--verify-ssl", "certs.pem", "https://example.com"])
+    assert _normalize_verify_ssl(args.verify_ssl) == "certs.pem"
+
+
+def test_verify_ssl_cli_no_verify_alias(parser: ArgumentParser) -> None:
+    """The --no-verify-ssl alias sets the value to False."""
+    args = parser.parse_args(["--no-verify-ssl", "https://example.com"])
+    assert args.verify_ssl is False
+    assert _normalize_verify_ssl(args.verify_ssl) is False
+
+
+@patch("mcp_proxy.httpx_client.httpx.AsyncClient")
+def test_custom_httpx_client_disable_ssl(mock_async_client: object) -> None:
+    """custom_httpx_client passes verify=False to httpx when disabled."""
+    custom_httpx_client(verify_ssl=False)
+    kwargs = mock_async_client.call_args.kwargs
+    assert kwargs["verify"] is False
+
+
+@patch("mcp_proxy.httpx_client.httpx.AsyncClient")
+def test_custom_httpx_client_cert_path(mock_async_client: object) -> None:
+    """custom_httpx_client forwards certificate bundle paths."""
+    custom_httpx_client(verify_ssl="/tmp/cert.pem")  # noqa: S108
+    kwargs = mock_async_client.call_args.kwargs
+    assert kwargs["verify"] == "/tmp/cert.pem"  # noqa: S108


### PR DESCRIPTION
- Enable HTTPS connection without running SSL verification. To do so, use --no-verify-ssl
- Add HTTPX hooks to log requests and responses. It helps to trace potential connectivity issues.