### PR TITLE
feat: add --log-level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ services:
 ```bash
 usage: mcp-proxy [-h] [--version] [-H KEY VALUE] [--transport {sse,streamablehttp}]
                  [-e KEY VALUE] [--cwd CWD]
-                 [--pass-environment | --no-pass-environment] [--debug | --no-debug]
+                 [--pass-environment | --no-pass-environment] [--log-level LEVEL] [--debug | --no-debug]
                  [--named-server NAME COMMAND_STRING]
                  [--named-server-config FILE_PATH] [--port PORT] [--host HOST]
                  [--stateless | --no-stateless] [--sse-port SSE_PORT]
@@ -346,7 +346,8 @@ stdio client options:
   --cwd CWD             The working directory to use when spawning the default server process. Named servers inherit the proxy's CWD.
   --pass-environment, --no-pass-environment
                         Pass through all environment variables when spawning all server processes.
-  --debug, --no-debug   Enable debug mode with detailed logging output.
+  --log-level LEVEL     Set the log level. Default is INFO.
+  --debug, --no-debug   Enable debug mode with detailed logging output. Equivalent to --log-level DEBUG. If both --debug and --log-level are provided, --debug takes precedence.
   --named-server NAME COMMAND_STRING
                         Define a named stdio server. NAME is for the URL path /servers/NAME/. COMMAND_STRING is a single string with the command and its arguments (e.g., 'uvx mcp-server-fetch --timeout 10'). These servers inherit the proxy's CWD and environment from --pass-environment.
   --named-server-config FILE_PATH

--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -132,9 +132,20 @@ def _add_arguments_to_parser(parser: argparse.ArgumentParser) -> None:
         default=False,
     )
     stdio_client_options.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        metavar="LEVEL",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the log level. Default is INFO.",
+    )
+    stdio_client_options.add_argument(
         "--debug",
         action=argparse.BooleanOptionalAction,
-        help="Enable debug mode with detailed logging output.",
+        help=(
+            "Enable debug mode with detailed logging output. Equivalent to --log-level DEBUG. "
+            "If both --debug and --log-level are provided, --debug takes precedence."
+        ),
         default=False,
     )
     stdio_client_options.add_argument(
@@ -203,10 +214,10 @@ def _add_arguments_to_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _setup_logging(*, debug: bool) -> logging.Logger:
+def _setup_logging(*, level: str, debug: bool) -> logging.Logger:
     """Set up logging configuration and return the logger."""
     logging.basicConfig(
-        level=logging.DEBUG if debug else logging.INFO,
+        level=logging.DEBUG if debug else level,
         format="[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s] %(message)s",
     )
     return logging.getLogger(__name__)
@@ -334,7 +345,7 @@ def _create_mcp_settings(args_parsed: argparse.Namespace) -> MCPServerSettings:
         port=args_parsed.port if args_parsed.port is not None else args_parsed.sse_port,
         stateless=args_parsed.stateless,
         allow_origins=args_parsed.allow_origin if len(args_parsed.allow_origin) > 0 else None,
-        log_level="DEBUG" if args_parsed.debug else "INFO",
+        log_level="DEBUG" if args_parsed.debug else args_parsed.log_level,
     )
 
 
@@ -342,7 +353,7 @@ def main() -> None:
     """Start the client using asyncio."""
     parser = _setup_argument_parser()
     args_parsed = parser.parse_args()
-    logger = _setup_logging(debug=args_parsed.debug)
+    logger = _setup_logging(level=args_parsed.log_level, debug=args_parsed.debug)
 
     # Validate required arguments
     if (


### PR DESCRIPTION
Fixes https://github.com/sparfenyuk/mcp-proxy/issues/95

This adds the option `--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}` to define the log level. If both `--debug` and `--log-level` are provided, the former takes precedence.