### PR TITLE
Server http support

### DIFF
--- a/src/mcp_proxy/http_client.py
+++ b/src/mcp_proxy/http_client.py
@@ -1,0 +1,27 @@
+"""Create a local server that proxies requests to a remote server over HTTP."""
+
+from typing import Any
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.server.stdio import stdio_server
+
+from .proxy_server import create_proxy_server
+
+
+async def run_http_client(url: str, headers: dict[str, Any] | None = None) -> None:
+    """Run the HTTP client.
+
+    Args:
+        url: The URL to connect to.
+        headers: Headers for connecting to MCP server.
+
+    """
+    async with streamablehttp_client(url=url, headers=headers) as streams, ClientSession(*streams) as session:
+        app = await create_proxy_server(session)
+        async with stdio_server() as (read_stream, write_stream):
+            await app.run(
+                read_stream,
+                write_stream,
+                app.create_initialization_options(),
+            )

--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -35,6 +35,7 @@ class MCPServerSettings:
     stateless: bool = False
     allow_origins: list[str] | None = None
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    transport: Literal["sse", "streamablehttp", "http"] = "sse"
 
 
 # To store last activity for multiple servers if needed, though status endpoint is global for now.
@@ -57,44 +58,68 @@ def create_single_instance_routes(
     mcp_server_instance: MCPServerSDK[object],
     *,
     stateless_instance: bool,
+    transport: Literal["sse", "streamablehttp", "http"] = "sse",
 ) -> tuple[list[BaseRoute], StreamableHTTPSessionManager]:  # Return the manager itself
     """Create Starlette routes and the HTTP session manager for a single MCP server instance."""
     logger.debug(
-        "Creating routes for a single MCP server instance (stateless: %s)",
+        "Creating routes for a single MCP server instance (stateless: %s, transport: %s)",
         stateless_instance,
+        transport,
     )
 
-    sse_transport = SseServerTransport("/messages/")
-    http_session_manager = StreamableHTTPSessionManager(
-        app=mcp_server_instance,
-        event_store=None,
-        json_response=True,
-        stateless=stateless_instance,
-    )
+    routes: list[BaseRoute] = []
 
-    async def handle_sse_instance(request: Request) -> Response:
-        async with sse_transport.connect_sse(
-            request.scope,
-            request.receive,
-            request._send,  # noqa: SLF001
-        ) as (read_stream, write_stream):
+    if transport in ("sse", "streamablehttp"):
+        sse_transport = SseServerTransport("/messages/")
+        http_session_manager = StreamableHTTPSessionManager(
+            app=mcp_server_instance,
+            event_store=None,
+            json_response=True,
+            stateless=stateless_instance,
+        )
+
+        async def handle_sse_instance(request: Request) -> Response:
+            async with sse_transport.connect_sse(
+                request.scope,
+                request.receive,
+                request._send,  # noqa: SLF001
+            ) as (read_stream, write_stream):
+                _update_global_activity()
+                await mcp_server_instance.run(
+                    read_stream,
+                    write_stream,
+                    mcp_server_instance.create_initialization_options(),
+                )
+            return Response()
+
+        async def handle_streamable_http_instance(scope: Scope, receive: Receive, send: Send) -> None:
             _update_global_activity()
-            await mcp_server_instance.run(
-                read_stream,
-                write_stream,
-                mcp_server_instance.create_initialization_options(),
-            )
-        return Response()
+            await http_session_manager.handle_request(scope, receive, send)
 
-    async def handle_streamable_http_instance(scope: Scope, receive: Receive, send: Send) -> None:
-        _update_global_activity()
-        await http_session_manager.handle_request(scope, receive, send)
+        routes.extend([
+            Mount("/mcp", app=handle_streamable_http_instance),
+            Route("/sse", endpoint=handle_sse_instance),
+            Mount("/messages/", app=sse_transport.handle_post_message),
+        ])
 
-    routes = [
-        Mount("/mcp", app=handle_streamable_http_instance),
-        Route("/sse", endpoint=handle_sse_instance),
-        Mount("/messages/", app=sse_transport.handle_post_message),
-    ]
+    elif transport == "http":
+        http_session_manager = StreamableHTTPSessionManager(
+            app=mcp_server_instance,
+            event_store=None,
+            json_response=True,
+            stateless=stateless_instance,
+        )
+
+        async def handle_http_instance(scope: Scope, receive: Receive, send: Send) -> None:
+            _update_global_activity()
+            await http_session_manager.handle_request(scope, receive, send)
+
+        routes.append(Mount("/", app=handle_http_instance))
+
+    else:
+        msg = f"Unsupported transport: {transport}"
+        raise ValueError(msg)
+
     return routes, http_session_manager
 
 
@@ -114,7 +139,7 @@ async def run_mcp_server(
     async with contextlib.AsyncExitStack() as stack:
         # Manage lifespans of all StreamableHTTPSessionManagers
         @contextlib.asynccontextmanager
-        async def combined_lifespan(_app: Starlette) -> AsyncIterator[None]:
+        async def combined_lifespan(_: Starlette) -> AsyncIterator[None]:
             logger.info("Main application lifespan starting...")
             # All http_session_managers' .run() are already entered into the stack
             yield
@@ -134,6 +159,7 @@ async def run_mcp_server(
             instance_routes, http_manager = create_single_instance_routes(
                 proxy,
                 stateless_instance=mcp_settings.stateless,
+                transport=mcp_settings.transport,
             )
             await stack.enter_async_context(http_manager.run())  # Manage lifespan by calling run()
             all_routes.extend(instance_routes)
@@ -154,6 +180,7 @@ async def run_mcp_server(
             instance_routes_named, http_manager_named = create_single_instance_routes(
                 proxy_named,
                 stateless_instance=mcp_settings.stateless,
+                transport=mcp_settings.transport,
             )
             await stack.enter_async_context(
                 http_manager_named.run(),
@@ -196,22 +223,33 @@ async def run_mcp_server(
         )
         http_server = uvicorn.Server(config)
 
-        # Print out the SSE URLs for all configured servers
+        # Print out the server URLs for all configured servers
         base_url = f"http://{mcp_settings.bind_host}:{mcp_settings.port}"
-        sse_urls = []
+        server_urls = []
 
         # Add default server if configured
         if default_server_params:
-            sse_urls.append(f"{base_url}/sse")
+            if mcp_settings.transport == "http":
+                server_urls.append(f"{base_url}/")
+            elif mcp_settings.transport == "streamablehttp":
+                server_urls.append(f"{base_url}/mcp")
+            else:  # sse
+                server_urls.append(f"{base_url}/sse")
 
         # Add named servers
-        sse_urls.extend([f"{base_url}/servers/{name}/sse" for name in named_server_params])
+        for name in named_server_params:
+            if mcp_settings.transport == "http":
+                server_urls.append(f"{base_url}/servers/{name}/")
+            elif mcp_settings.transport == "streamablehttp":
+                server_urls.append(f"{base_url}/servers/{name}/mcp")
+            else:  # sse
+                server_urls.append(f"{base_url}/servers/{name}/sse")
 
-        # Display the SSE URLs prominently
-        if sse_urls:
-            # Using print directly for user visibility, with noqa to ignore linter warnings
-            logger.info("Serving MCP Servers via SSE:")
-            for url in sse_urls:
+        # Display the server URLs prominently
+        if server_urls:
+            transport_name = mcp_settings.transport.upper()
+            logger.info("Serving MCP Servers via %s:", transport_name)
+            for url in server_urls:
                 logger.info("  - %s", url)
 
         logger.debug(

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,61 @@
+"""Tests for the HTTP client."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from mcp_proxy.http_client import run_http_client
+
+
+@pytest.mark.asyncio
+async def test_run_http_client():
+    """Test HTTP client run function."""
+    url = "http://example.com/"
+    headers = {"Authorization": "Bearer token"}
+
+    with patch("mcp_proxy.http_client.streamablehttp_client") as mock_http_client, \
+         patch("mcp_proxy.http_client.ClientSession") as mock_session, \
+         patch("mcp_proxy.http_client.create_proxy_server") as mock_create_proxy, \
+         patch("mcp_proxy.http_client.stdio_server") as mock_stdio:
+
+        # Setup mocks
+        mock_streams = (AsyncMock(), AsyncMock())
+        mock_http_client.return_value.__aenter__.return_value = mock_streams
+        mock_session.return_value.__aenter__.return_value = AsyncMock()
+        mock_proxy = AsyncMock()
+        mock_create_proxy.return_value = mock_proxy
+        mock_stdio.return_value.__aenter__.return_value = (AsyncMock(), AsyncMock())
+
+        # Run the client
+        await run_http_client(url, headers)
+
+        # Verify calls
+        mock_http_client.assert_called_once_with(url=url, headers=headers)
+        mock_create_proxy.assert_called_once()
+        mock_proxy.run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_http_client_no_headers():
+    """Test HTTP client run function without headers."""
+    url = "http://example.com/"
+
+    with patch("mcp_proxy.http_client.streamablehttp_client") as mock_http_client, \
+         patch("mcp_proxy.http_client.ClientSession") as mock_session, \
+         patch("mcp_proxy.http_client.create_proxy_server") as mock_create_proxy, \
+         patch("mcp_proxy.http_client.stdio_server") as mock_stdio:
+
+        # Setup mocks
+        mock_streams = (AsyncMock(), AsyncMock())
+        mock_http_client.return_value.__aenter__.return_value = mock_streams
+        mock_session.return_value.__aenter__.return_value = AsyncMock()
+        mock_proxy = AsyncMock()
+        mock_create_proxy.return_value = mock_proxy
+        mock_stdio.return_value.__aenter__.return_value = (AsyncMock(), AsyncMock())
+
+        # Run the client
+        await run_http_client(url)
+
+        # Verify calls
+        mock_http_client.assert_called_once_with(url=url, headers=None)
+        mock_create_proxy.assert_called_once()
+        mock_proxy.run.assert_called_once()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -44,7 +44,7 @@ def create_starlette_app(
     routes, http_manager = create_single_instance_routes(
         mcp_server,
         stateless_instance=stateless,
-        transport=transport
+        transport=transport,
     )
 
     middleware: list[Middleware] = []
@@ -133,10 +133,10 @@ async def test_sse_transport() -> None:
 
 
 async def test_http_transport() -> None:
-    """Test HTTP transport layer functionality."""
-    server = make_background_server(debug=True)
+    """Test streamablehttp transport layer functionality."""
+    server = make_background_server(debug=True, transport="streamablehttp")
     async with server.run_in_background():
-        http_url = f"{server.url}/mcp/"
+        http_url = f"{server.url}/mcp"
         async with (
             streamablehttp_client(url=http_url) as (read, write, _),
             ClientSession(read, write) as session,
@@ -154,10 +154,10 @@ async def test_http_transport() -> None:
 
 
 async def test_stateless_http_transport() -> None:
-    """Test stateless HTTP transport functionality."""
-    server = make_background_server(debug=True, stateless=True)
+    """Test stateless streamablehttp transport functionality."""
+    server = make_background_server(debug=True, stateless=True, transport="streamablehttp")
     async with server.run_in_background():
-        http_url = f"{server.url}/mcp/"
+        http_url = f"{server.url}/mcp"
         async with (
             streamablehttp_client(url=http_url) as (read, write, _),
             ClientSession(read, write) as session,
@@ -181,7 +181,7 @@ async def test_pure_http_transport() -> None:
     """Test pure HTTP transport functionality."""
     server = make_background_server(debug=True, transport="http")
     async with server.run_in_background():
-        http_url = f"{server.url}/"
+        http_url = f"{server.url}/mcp"
         async with (
             streamablehttp_client(url=http_url) as (read, write, _),
             ClientSession(read, write) as session,


### PR DESCRIPTION
Now you can add use http transport when `--server-transport http` is set. Tools will be available at /mcp/ path