### PR TITLE
feat: add dynamic token support via HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ For Claude Desktop, the configuration entry can look like this:
   "mcpServers": {
     "mcp-proxy": {
       "command": "mcp-proxy",
-      "args": [
-        "http://example.io/sse"
-      ],
+      "args": ["http://example.io/sse"],
       "env": {
         "API_ACCESS_TOKEN": "access-token"
       }
@@ -182,22 +180,20 @@ The JSON file should follow this structure:
       "disabled": false,
       "timeout": 60,
       "command": "uvx",
-      "args": [
-        "mcp-server-fetch"
-      ],
+      "args": ["mcp-server-fetch"],
       "transportType": "stdio"
     },
     "github": {
       "timeout": 60,
       "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-github"
-      ],
+      "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
       },
-      "transportType": "stdio"
+      "transportType": "stdio",
+      "headerToEnv": {
+        "Authorization": "GITHUB_PERSONAL_ACCESS_TOKEN"
+      }
     }
   }
 }
@@ -207,7 +203,72 @@ The JSON file should follow this structure:
 - `command`: (Required) The command to execute for the stdio server.
 - `args`: (Optional) A list of arguments for the command. Defaults to an empty list.
 - `enabled`: (Optional) If `false`, this server definition will be skipped. Defaults to `true`.
+- `env`: (Optional) Static environment variables to pass to the stdio server.
+- `headerToEnv`: (Optional) Dynamic mapping of HTTP headers to environment variables. When a request comes in with the specified header, its value will be passed as an environment variable to the stdio server.
 - `timeout` and `transportType`: These fields are present in standard MCP client configurations but are currently **ignored** by `mcp-proxy` when loading named servers. The transport type is implicitly "stdio".
+
+## Dynamic Token Support
+
+`mcp-proxy` supports dynamic token extraction from HTTP headers. This allows you to pass authentication tokens with each request instead of hardcoding them in the configuration.
+
+### How it works
+
+1. **Configure header mapping**: In your server configuration, add a `headerToEnv` section that maps HTTP header names to environment variable names.
+2. **Send requests with headers**: When making requests to your MCP servers, include the required headers with your tokens.
+3. **Automatic token extraction**: `mcp-proxy` automatically extracts the tokens from headers and passes them as environment variables to the stdio processes.
+
+### Example Usage
+
+**Configuration:**
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "headerToEnv": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "GITHUB_PERSONAL_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**HTTP Request:**
+
+```http
+GET /servers/github/sse HTTP/1.1
+Host: localhost:8080
+GITHUB_PERSONAL_ACCESS_TOKEN: ghp_1234567890abcdef
+```
+
+**Result:** The GitHub MCP server will receive `GITHUB_PERSONAL_ACCESS_TOKEN=ghp_1234567890abcdef` as an environment variable.
+
+### Multiple Tokens
+
+You can configure multiple header mappings for a single server:
+
+```json
+{
+  "mcpServers": {
+    "bitrix": {
+      "command": "python3",
+      "args": ["mcp-bitrix/mcp_server.py"],
+      "headerToEnv": {
+        "Authorization": "BITRIX_WEBHOOK_URL",
+        "X-Bitrix-Signature": "BITRIX_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### Security Considerations
+
+- **Token validation**: Consider implementing token validation in your MCP servers.
+- **HTTPS only**: Always use HTTPS in production to protect tokens in transit.
+- **Token rotation**: Implement token rotation mechanisms for enhanced security.
 
 ## Installation
 
@@ -253,6 +314,7 @@ docker run --rm -t ghcr.io/sparfenyuk/mcp-proxy:v0.3.2-alpine --help
 
   **Solution**: Try to use the full path to the binary. To do so, open a terminal and run the command`which mcp-proxy` (
   macOS, Linux) or `where.exe mcp-proxy` (Windows). Then, use the output path as a value for 'command' attribute:
+
   ```json
     "fetch": {
       "command": "/full/path/to/bin/mcp-proxy",
@@ -374,18 +436,13 @@ Examples:
       "enabled": true,
       "timeout": 60,
       "command": "uvx",
-      "args": [
-        "mcp-server-fetch"
-      ],
+      "args": ["mcp-server-fetch"],
       "transportType": "stdio"
     },
     "github": {
       "timeout": 60,
       "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-github"
-      ],
+      "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
       },

--- a/config_example.json
+++ b/config_example.json
@@ -10,14 +10,45 @@
       "transportType": "stdio"
     },
     "github": {
+      "enabled": true,
+      "timeout": 60,
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github",
+        "--toolsets",
+        "repos,issues,context,projects,gists"
+      ],
+      "transportType": "stdio",
+      "headerToEnv": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "GITHUB_PERSONAL_ACCESS_TOKEN"
+      }
+    },
+    "bitrix24": {
+      "enabled": false,
+      "timeout": 60,
+      "command": "python3",
+      "args": [
+        "mcp-bitrix/mcp_server.py"
+      ],
+      "transportType": "stdio",
+      "headerToEnv": {
+        "BITRIX_WEBHOOK_URL": "BITRIX_WEBHOOK_URL",
+        "BITRIX_ACCESS_TOKEN": "BITRIX_ACCESS_TOKEN"
+      }
+    },
+    "context7": {
       "enabled": false,
       "timeout": 60,
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-github"
+        "@upstash/context7-mcp"
       ],
-      "transportType": "stdio"
+      "transportType": "stdio",
+      "headerToEnv": {
+        "CONTEXT7_API_KEY": "CONTEXT7_API_KEY"
+      }
     }
   }
 }

--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -19,7 +19,7 @@ from importlib.metadata import version
 from mcp.client.stdio import StdioServerParameters
 
 from .config_loader import load_named_server_configs_from_file
-from .mcp_server import MCPServerSettings, run_mcp_server
+from .mcp_server import MCPServerSettings, run_mcp_server_with_dynamic_tokens
 from .sse_client import run_sse_client
 from .streamablehttp_client import run_streamablehttp_client
 
@@ -278,7 +278,7 @@ def _load_named_servers_from_config(
     config_path: str,
     base_env: dict[str, str],
     logger: logging.Logger,
-) -> dict[str, StdioServerParameters]:
+) -> tuple[dict[str, StdioServerParameters], dict[str, dict[str, str]]]:
     """Load named server configurations from a file."""
     try:
         return load_named_server_configs_from_file(config_path, base_env)
@@ -388,12 +388,13 @@ def main() -> None:
 
     # Configure named servers
     named_stdio_params: dict[str, StdioServerParameters] = {}
+    header_mappings: dict[str, dict[str, str]] = {}
     if args_parsed.named_server_config:
         if args_parsed.named_server_definitions:
             logger.warning(
                 "--named-server CLI arguments are ignored when --named-server-config is provided.",
             )
-        named_stdio_params = _load_named_servers_from_config(
+        named_stdio_params, header_mappings = _load_named_servers_from_config(
             args_parsed.named_server_config,
             base_env,
             logger,
@@ -416,9 +417,10 @@ def main() -> None:
     # Create MCP server settings and run the server
     mcp_settings = _create_mcp_settings(args_parsed)
     asyncio.run(
-        run_mcp_server(
+        run_mcp_server_with_dynamic_tokens(
             default_server_params=default_stdio_params,
             named_server_params=named_stdio_params,
+            header_mappings=header_mappings,
             mcp_settings=mcp_settings,
         ),
     )

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -57,7 +57,7 @@ def test_load_valid_config(create_temp_config_file: Callable[[dict[str, t.Any]],
     base_env = {"PASSED": "env_value"}
     base_env_with_added_env = {"PASSED": "env_value", "FOO": "bar"}
 
-    loaded_params = load_named_server_configs_from_file(tmp_config_path, base_env)
+    loaded_params, header_mappings = load_named_server_configs_from_file(tmp_config_path, base_env)
 
     assert "server1" in loaded_params
     assert loaded_params["server1"].command == "echo"
@@ -85,7 +85,7 @@ def test_load_config_with_not_enabled_server(
         },
     }
     tmp_config_path = create_temp_config_file(config_content)
-    loaded_params = load_named_server_configs_from_file(tmp_config_path, {})
+    loaded_params, header_mappings = load_named_server_configs_from_file(tmp_config_path, {})
 
     assert "explicitly_enabled_server" in loaded_params
     assert loaded_params["explicitly_enabled_server"].command == "true_command"
@@ -135,7 +135,7 @@ def test_load_example_fetch_config_if_uvx_exists() -> None:
         )
 
     base_env = {"EXAMPLE_ENV": "true"}
-    loaded_params = load_named_server_configs_from_file(example_config_path, base_env)
+    loaded_params, header_mappings = load_named_server_configs_from_file(example_config_path, base_env)
 
     assert "fetch" in loaded_params
     fetch_param = loaded_params["fetch"]
@@ -167,7 +167,7 @@ def test_invalid_server_entry_not_dict(
     config_content = {"mcpServers": {"server1": "not_a_dict"}}
     tmp_config_path = create_temp_config_file(config_content)
 
-    loaded_params = load_named_server_configs_from_file(tmp_config_path, {})
+    loaded_params, header_mappings = load_named_server_configs_from_file(tmp_config_path, {})
     assert len(loaded_params) == 0  # No servers should be loaded
     mock_logger.warning.assert_called_with(
         "Skipping invalid server config for '%s' in %s. Entry is not a dictionary.",
@@ -184,7 +184,7 @@ def test_server_entry_missing_command(
     """Test handling of server entries missing the command field."""
     config_content = {"mcpServers": {"server_no_command": {"args": ["arg1"]}}}
     tmp_config_path = create_temp_config_file(config_content)
-    loaded_params = load_named_server_configs_from_file(tmp_config_path, {})
+    loaded_params, header_mappings = load_named_server_configs_from_file(tmp_config_path, {})
     assert "server_no_command" not in loaded_params
     mock_logger.warning.assert_called_with(
         "Named server '%s' from config is missing 'command'. Skipping.",
@@ -204,7 +204,7 @@ def test_server_entry_invalid_args_type(
         },
     }
     tmp_config_path = create_temp_config_file(config_content)
-    loaded_params = load_named_server_configs_from_file(tmp_config_path, {})
+    loaded_params, header_mappings = load_named_server_configs_from_file(tmp_config_path, {})
     assert "server_invalid_args" not in loaded_params
     mock_logger.warning.assert_called_with(
         "Named server '%s' from config has invalid 'args' (must be a list). Skipping.",
@@ -216,7 +216,7 @@ def test_empty_mcpservers_dict(create_temp_config_file: Callable[[dict[str, t.An
     """Test handling of configuration files with empty mcpServers dictionary."""
     config_content: dict[str, t.Any] = {"mcpServers": {}}
     tmp_config_path = create_temp_config_file(config_content)
-    loaded_params = load_named_server_configs_from_file(tmp_config_path, {})
+    loaded_params, header_mappings = load_named_server_configs_from_file(tmp_config_path, {})
     assert len(loaded_params) == 0
 
 


### PR DESCRIPTION
- Add headerToEnv parameter for mapping HTTP headers to environment variables
- Implement run_mcp_server_with_dynamic_tokens function for dynamic token handling
- Update documentation with dynamic token usage examples
- Extend config_example.json with GitHub, Bitrix24, Context7 server examples
- Update tests to support new functionality
- Improve security by passing tokens via headers instead of static env vars