### PR TITLE
Update server description to mention streamable HTTP or SSE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-proxy"
-description = "A MCP server which proxies requests to a remote MCP server over SSE transport."
+description = "A MCP server which proxies requests to a remote MCP server over streamable HTTP or SSE."
 authors = [{ name = "Sergey Parfenyuk", email = "sergey.parfenyuk@gmail.com" }]
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
Hey from Anthropic 👋. Thanks for a cool project in the MCP space :)

This PR updates the project description to clarify that the server supports both streamable HTTP and SSE transport protocols. This appears at the top of the PyPi page and confused a couple of our customers about what was supported - given we're keen for people to migrate to streamable HTTP (better reliability, better compatibility, and more resource efficient) we wanted to clarify the support here.