### PR TITLE
Fix StreamableHTTP re-init after session 404

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Quick Memory Usage
+
+- **Default endpoint:** `mcp-proxy` (inherits `shared`; includeShared is on by default). Keep `project` = `mcp-proxy` on all entries.
+- **Cold start each session:** `listRecentEntries { endpoint:"mcp-proxy", maxResults:20 }` to catch up before doing work.
+- **Common flow:** `searchEntries` for the topic at hand; then `upsertEntry`/`patchEntry` with concise `title`, `kind` (`procedure`/`decision`/`note`), 3–6 tags (e.g., `mcp-proxy`, `run`, `wsl`, `dotnet`, `tests`, `decision`), and any `epicSlug`/`case` links.
+- **Recording lessons:** capture steps, validation, root cause, and follow-ups; set `isPermanent=false` unless explicitly canonical. Prefer relations to existing IDs instead of duplicating context.
+- **Prompts repository:** prompt templates live in `prompts-repository` (`prompts/list` → `prompts/get`)—use these instead of copying prompts by hand.
+- **Operational tips:** if commands time out, restart the session and re-run `listProjects`; keep secrets out of entries and omit credentials/PHI.
+
+# Build / Tooling Notes (WSL on /mnt)
+
+- Repo is under `/mnt/...`; prefer Windows .NET SDK to avoid I/O slowness. Set `NEXPORT_WINDOTNET="/mnt/c/Program Files/dotnet/"` and use `"$NEXPORT_WINDOTNETdotnet.exe"` for restore/build/test.
+- Keep repo under `/mnt` (do not relocate) and use the Windows Git binary if available at `/mnt/c/Program Files/Git/bin/git.exe` for faster operations.
+
+# Dev Notes (mcp-proxy codebase)
+
+- Python project (pyproject; Python ≥3.10). Install deps with `uv sync`; run tests via `uv run pytest` (uses importlib mode; dev deps defined under `[tool.uv]`). Lint/type-check via `uv run ruff check` and `uv run mypy src`.
+- CLI entrypoint `mcp-proxy` supports two modes: SSE/StreamableHTTP client (URL first arg; use `--transport streamablehttp` for /mcp endpoints; `API_ACCESS_TOKEN` env auto-adds `Authorization: Bearer …`) and stdio→SSE server (`mcp-proxy --port 8080 <stdio command> ...`; add `--pass-environment` if child needs current env).
+- Named servers: define multiple stdio servers via repeated `--named-server NAME 'command args'` or `--named-server-config servers.json` (expects top-level `mcpServers` with `command`, optional `args`, `enabled`; bad/disabled entries are skipped, config errors exit 1).
+- Reliability: opt-in retry flag `--retry-remote` (default off) retries the remote MCP once; use `--remote-retries N` to set the retry count (backoff 0.5s).
+- HTTP/CORS: set `--allow-origin '*'` when exposing to browsers; `--stateless` toggles Streamable HTTP stateless mode. Deprecated flags `--sse-host/--sse-port` map to `--host/--port`.
+- Env defaults: `SSE_URL` provides fallback for `command_or_url`; `API_ACCESS_TOKEN` and `-H/--headers` combine for upstream auth; `--debug` forces log level DEBUG.

--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Examples:
   mcp-proxy --headers Authorization 'Bearer YOUR_TOKEN' http://localhost:8080/sse
   mcp-proxy -H X-Api-Key "$API_KEY" --no-verify-ssl https://example.com/mcp
   mcp-proxy --transport streamablehttp -H Authorization "Bearer $TOKEN" --remote-retries 1 https://example.com/mcp
+  mcp-proxy -H X-Api-Key "$API_KEY" -H User-Agent "mcp-proxy/cli" https://example.com/sse
   mcp-proxy --client-id CLIENT_ID --client-secret CLIENT_SECRET --token-url https://auth.example.com/token http://localhost:8080/sse
   mcp-proxy --port 8080 -- your-command --arg1 value1 --arg2 value2
   mcp-proxy --named-server fetch 'uvx mcp-server-fetch' --port 8080

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Environment Variables
 | ------------------ | -------- | ---------------------------------------------------------------------------- | ---------- |
 | `API_ACCESS_TOKEN` | No       | Can be used instead of `--headers Authorization 'Bearer <API_ACCESS_TOKEN>'` | YOUR_TOKEN |
 | `MCP_PROXY_CALL_TIMEOUT_S` | No | Per-call timeout in seconds before retrying (set ≤0 to disable). Helpful for detecting stalled SSE responses. | 10 |
+| `MCP_PROXY_REINIT_TIMEOUT_S` | No | Timeout in seconds for re-initializing sessions after 404/session errors (set ≤0 to disable and use per-call timeout). | 5 |
 | `MCP_PROXY_RECONNECT_TIMEOUT_S` | No | Timeout in seconds for rebuilding the StreamableHTTP transport (opening new stream + session). | 5 |
 
 When using StreamableHTTP, if the remote server returns HTTP 404 for a request that includes an `MCP-Session-Id`, `mcp-proxy` will clear the session id and force a fresh `initialize` before the next call. This follows the MCP transport spec for session invalidation.

--- a/README.md
+++ b/README.md
@@ -335,6 +335,9 @@ SSE/StreamableHTTP client options:
                         Headers to pass to the SSE server. Can be used multiple times.
   --transport {sse,streamablehttp}
                         The transport to use for the client. Default is SSE.
+  --retry-remote, --no-retry-remote
+                        Retry the remote MCP server once on connection/request failure (default: off). Use --remote-retries for a custom count.
+  --remote-retries N    Retry the remote MCP server N times on failure (default 0). Overrides --retry-remote count.
   --verify-ssl [VALUE]  Control SSL verification when acting as a client. Use without a value to force verification, pass 'false' to disable, or provide a path to a PEM bundle.
   --no-verify-ssl       Disable SSL verification (alias for --verify-ssl false).
   --client-id CLIENT_ID
@@ -371,6 +374,7 @@ Examples:
   mcp-proxy http://localhost:8080/sse
   mcp-proxy --no-verify-ssl https://server.local/sse
   mcp-proxy --transport streamablehttp http://localhost:8080/mcp
+  mcp-proxy --transport streamablehttp --remote-retries 2 http://localhost:8080/mcp
   mcp-proxy --headers Authorization 'Bearer YOUR_TOKEN' http://localhost:8080/sse
   mcp-proxy --client-id CLIENT_ID --client-secret CLIENT_SECRET --token-url https://auth.example.com/token http://localhost:8080/sse
   mcp-proxy --port 8080 -- your-command --arg1 value1 --arg2 value2

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Environment Variables
 | ------------------ | -------- | ---------------------------------------------------------------------------- | ---------- |
 | `API_ACCESS_TOKEN` | No       | Can be used instead of `--headers Authorization 'Bearer <API_ACCESS_TOKEN>'` | YOUR_TOKEN |
 | `MCP_PROXY_CALL_TIMEOUT_S` | No | Per-call timeout in seconds before retrying (set ≤0 to disable). Helpful for detecting stalled SSE responses. | 10 |
+| `MCP_PROXY_RECONNECT_TIMEOUT_S` | No | Timeout in seconds for rebuilding the StreamableHTTP transport (opening new stream + session). | 5 |
+
+When using StreamableHTTP, if the remote server returns HTTP 404 for a request that includes an `MCP-Session-Id`, `mcp-proxy` will clear the session id and force a fresh `initialize` before the next call. This follows the MCP transport spec for session invalidation.
 
 ### 1.2 Example usage
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ graph LR
 
 This mode requires providing the URL of the MCP Server's SSE endpoint as the program’s first argument. If the server uses Streamable HTTP transport, make sure to enforce it on the `mcp-proxy` side by passing `--transport=streamablehttp`.
 
+Authentication and headers:
+- Use `-H/--headers KEY VALUE` for custom headers (repeatable). Example: `-H X-Api-Key "$API_KEY" -H User-Agent "mcp-proxy"`.
+- If `API_ACCESS_TOKEN` env var is set, `mcp-proxy` automatically adds `Authorization: Bearer <token>`.
+- Disable SSL verification for dev/self-signed endpoints with `--no-verify-ssl` (alias: `--verify-ssl false`).
+
 Arguments
 
 | Name             | Required | Description                                                                                                       | Example                                       |
@@ -60,6 +65,7 @@ Arguments
 | `command_or_url` | Yes      | The MCP server SSE endpoint to connect to                                                                         | http://example.io/sse                         |
 | `--headers`      | No       | Headers to use for the MCP server SSE connection                                                                  | Authorization 'Bearer my-secret-access-token' |
 | `--transport`    | No       | Decides which transport protocol to use when connecting to an MCP server. Can be either 'sse' or 'streamablehttp' | streamablehttp                                |
+| `--retry-remote` / `--remote-retries N` | No | Retry remote MCP once (`--retry-remote`) or N times (`--remote-retries`) on transient failures | --remote-retries 2                            |
 | `--client-id`    | No       | OAuth2 client ID for authentication                                                                               | your_client_id                                |
 | `--client-secret`| No       | OAuth2 client secret for authentication                                                                           | your_client_secret                            |
 | `--token-url`    | No       | OAuth2 token endpoint URL for authentication                                                                      | https://auth.example.com/oauth/token          |
@@ -376,6 +382,7 @@ Examples:
   mcp-proxy --transport streamablehttp http://localhost:8080/mcp
   mcp-proxy --transport streamablehttp --remote-retries 2 http://localhost:8080/mcp
   mcp-proxy --headers Authorization 'Bearer YOUR_TOKEN' http://localhost:8080/sse
+  mcp-proxy -H X-Api-Key "$API_KEY" --no-verify-ssl https://example.com/mcp
   mcp-proxy --client-id CLIENT_ID --client-secret CLIENT_SECRET --token-url https://auth.example.com/token http://localhost:8080/sse
   mcp-proxy --port 8080 -- your-command --arg1 value1 --arg2 value2
   mcp-proxy --named-server fetch 'uvx mcp-server-fetch' --port 8080

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Environment Variables
 | Name               | Required | Description                                                                  | Example    |
 | ------------------ | -------- | ---------------------------------------------------------------------------- | ---------- |
 | `API_ACCESS_TOKEN` | No       | Can be used instead of `--headers Authorization 'Bearer <API_ACCESS_TOKEN>'` | YOUR_TOKEN |
+| `MCP_PROXY_CALL_TIMEOUT_S` | No | Per-call timeout in seconds before retrying (set ≤0 to disable). Helpful for detecting stalled SSE responses. | 10 |
 
 ### 1.2 Example usage
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ graph LR
 This mode requires providing the URL of the MCP Server's SSE endpoint as the program’s first argument. If the server uses Streamable HTTP transport, make sure to enforce it on the `mcp-proxy` side by passing `--transport=streamablehttp`.
 
 Authentication and headers:
-- Use `-H/--headers KEY VALUE` for custom headers (repeatable). Example: `-H X-Api-Key "$API_KEY" -H User-Agent "mcp-proxy"`.
+- Use `-H/--headers KEY VALUE` for custom headers (repeat once per header). Example: `-H X-Api-Key "$API_KEY" -H User-Agent "mcp-proxy"`.
 - If `API_ACCESS_TOKEN` env var is set, `mcp-proxy` automatically adds `Authorization: Bearer <token>`.
-- Disable SSL verification for dev/self-signed endpoints with `--no-verify-ssl` (alias: `--verify-ssl false`).
+- Disable SSL verification for dev/self-signed endpoints with `--no-verify-ssl` (alias: `--verify-ssl false`); avoid in production.
 
 Arguments
 
@@ -383,6 +383,7 @@ Examples:
   mcp-proxy --transport streamablehttp --remote-retries 2 http://localhost:8080/mcp
   mcp-proxy --headers Authorization 'Bearer YOUR_TOKEN' http://localhost:8080/sse
   mcp-proxy -H X-Api-Key "$API_KEY" --no-verify-ssl https://example.com/mcp
+  mcp-proxy --transport streamablehttp -H Authorization "Bearer $TOKEN" --remote-retries 1 https://example.com/mcp
   mcp-proxy --client-id CLIENT_ID --client-secret CLIENT_SECRET --token-url https://auth.example.com/token http://localhost:8080/sse
   mcp-proxy --port 8080 -- your-command --arg1 value1 --arg2 value2
   mcp-proxy --named-server fetch 'uvx mcp-server-fetch' --port 8080

--- a/docs/auto-retry/plan.md
+++ b/docs/auto-retry/plan.md
@@ -1,0 +1,25 @@
+# Auto-retry and clearer messaging for upstream failures
+
+Purpose: capture the work needed so future agents can make mcp-proxy recover and report better when the upstream MCP endpoint (e.g., StreamableHTTP at `/mcp/`) drops or returns errors (as seen in the “Session terminated” logs).
+
+## Context / signals
+- Log excerpt (2025-12-09 03:17 UTC): upstream `POST http://localhost:5080/mcp` returned 404; immediately after, `resources/list` failed with `32600: Session terminated`, followed by cascading `-32601 Method not found` for multiple servers. Codex had to restart.
+- Likely causes: backend restart/unavailable route, path without trailing slash, or transient 4xx/5xx leading to lost session.
+
+## Goals
+- Proxy should self-heal from transient upstream failures (404/4xx/5xx/connection reset) by re-initializing once before surfacing errors.
+- If recovery fails, emit actionable messages (include URL, status code, hint about `/mcp/` path, and “backend unavailable” guidance) instead of opaque “Session terminated.”
+
+## Plan (iteration outline)
+- [ ] Add **opt-in** auto-retry for remote StreamableHTTP/SSE init and request failures (single quick retry with backoff) behind `--retry-remote` (default: off) and configurable attempts via `--remote-retries N`.
+- [ ] Normalize and log the exact upstream URL used (including trailing slash handling) so 404s point to a real path mismatch.
+- [ ] When upstream returns non-200/202 or the session dies (`32600 Session terminated`), attempt one re-init; if that fails, return a richer error to the client.
+- [ ] Improve logging/messages surfaced to clients: include status code, upstream URL, and suggestion to check backend health/path/auth.
+- [ ] Tests: add unit/integration coverage for (a) 404 on first call then success on retry, (b) connection reset, (c) ensure no infinite retry loops.
+
+## Open decisions
+- (Decided) Surface guidance in logs only; keep MCP error payload minimal/standard to avoid leaks and client incompatibility.
+
+## Artifacts to update
+- CLI help/README for the new retry flag (if introduced).
+- Change log entry noting improved resilience and clearer upstream error messaging.

--- a/docs/auto-retry/plan.md
+++ b/docs/auto-retry/plan.md
@@ -11,11 +11,11 @@ Purpose: capture the work needed so future agents can make mcp-proxy recover and
 - If recovery fails, emit actionable messages (include URL, status code, hint about `/mcp/` path, and “backend unavailable” guidance) instead of opaque “Session terminated.”
 
 ## Plan (iteration outline)
-- [ ] Add **opt-in** auto-retry for remote StreamableHTTP/SSE init and request failures (single quick retry with backoff) behind `--retry-remote` (default: off) and configurable attempts via `--remote-retries N`.
+- [x] Add **opt-in** auto-retry for remote StreamableHTTP/SSE init and request failures (single quick retry with backoff) behind `--retry-remote` (default: off) and configurable attempts via `--remote-retries N`.
 - [ ] Normalize and log the exact upstream URL used (including trailing slash handling) so 404s point to a real path mismatch.
-- [ ] When upstream returns non-200/202 or the session dies (`32600 Session terminated`), attempt one re-init; if that fails, return a richer error to the client.
+- [x] When upstream returns non-200/202 or the session dies (`32600 Session terminated`), attempt one re-init; if that fails, return a richer error to the client.
 - [ ] Improve logging/messages surfaced to clients: include status code, upstream URL, and suggestion to check backend health/path/auth.
-- [ ] Tests: add unit/integration coverage for (a) 404 on first call then success on retry, (b) connection reset, (c) ensure no infinite retry loops.
+- [x] Tests: added coverage for retryable 404s, send-path errors, call timeouts, and retry-budget guard. Connection-reset coverage still TODO.
 
 ## Open decisions
 - (Decided) Surface guidance in logs only; keep MCP error payload minimal/standard to avoid leaks and client incompatibility.

--- a/docs/auto-retry/plan.md
+++ b/docs/auto-retry/plan.md
@@ -15,8 +15,9 @@ Purpose: capture the work needed so future agents can make mcp-proxy recover and
 - [ ] Normalize and log the exact upstream URL used (including trailing slash handling) so 404s point to a real path mismatch.
 - [x] When upstream returns non-200/202 or the session dies (`32600 Session terminated`), attempt one re-init; if that fails, return a richer error to the client.
 - [x] Surface send-path HTTP errors (e.g., 404 on POST) via an error queue so retries can re-init the session instead of silently timing out.
-- [ ] Improve logging/messages surfaced to clients: include status code, upstream URL, and suggestion to check backend health/path/auth.
-- [x] Tests: added coverage for retryable 404s, send-path errors, call timeouts, and retry-budget guard. Connection-reset coverage still TODO.
+- [x] On HTTP 404 after idle, re-initialize the session first (clearing `MCP-Session-Id`), and only rebuild the transport if re-init fails; add test coverage for idle 404 + rebuild fallback.
+- [x] Improve logging/messages surfaced to clients: include status code, upstream URL, and suggestion to check backend health/path/auth.
+- [x] Tests: added coverage for retryable 404s, send-path errors, call timeouts, retry-budget guard, and connection-reset retry.
 
 ## Open decisions
 - (Decided) Surface guidance in logs only; keep MCP error payload minimal/standard to avoid leaks and client incompatibility.

--- a/docs/auto-retry/plan.md
+++ b/docs/auto-retry/plan.md
@@ -14,6 +14,7 @@ Purpose: capture the work needed so future agents can make mcp-proxy recover and
 - [x] Add **opt-in** auto-retry for remote StreamableHTTP/SSE init and request failures (single quick retry with backoff) behind `--retry-remote` (default: off) and configurable attempts via `--remote-retries N`.
 - [ ] Normalize and log the exact upstream URL used (including trailing slash handling) so 404s point to a real path mismatch.
 - [x] When upstream returns non-200/202 or the session dies (`32600 Session terminated`), attempt one re-init; if that fails, return a richer error to the client.
+- [x] Surface send-path HTTP errors (e.g., 404 on POST) via an error queue so retries can re-init the session instead of silently timing out.
 - [ ] Improve logging/messages surfaced to clients: include status code, upstream URL, and suggestion to check backend health/path/auth.
 - [x] Tests: added coverage for retryable 404s, send-path errors, call timeouts, and retry-budget guard. Connection-reset coverage still TODO.
 

--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -321,9 +321,9 @@ def _handle_sse_client_mode(
         else None
     )
 
-    retry_attempts = max(0, args_parsed.remote_retries or 0)
-    if args_parsed.retry_remote and retry_attempts == 0:
-        retry_attempts = 1
+    # Ensure at least one retry so transient/session errors trigger a re-init by default
+    retry_attempts = args_parsed.remote_retries or 0
+    retry_attempts = max(1, retry_attempts)
 
     if args_parsed.transport == "streamablehttp":
         asyncio.run(

--- a/src/mcp_proxy/httpx_client.py
+++ b/src/mcp_proxy/httpx_client.py
@@ -134,6 +134,18 @@ def custom_httpx_client(  # noqa: C901
                 request_state["last_get_status"] = response.status_code
                 request_state["last_get_url"] = str(response.request.url)
                 request_state["last_get_session_id"] = response.request.headers.get("mcp-session-id")
+            session_id = response.headers.get("mcp-session-id")
+            if session_id:
+                prev_session_id = request_state.get("last_session_id")
+                if prev_session_id and prev_session_id != session_id:
+                    logger.info(
+                        "MCP session id changed: %s -> %s (from %s %s)",
+                        prev_session_id,
+                        session_id,
+                        response.request.method,
+                        response.request.url,
+                    )
+                request_state["last_session_id"] = session_id
 
         # Treat any 4xx and 503 as retryable to trigger outer reconnect/re-init logic.
         status = response.status_code

--- a/src/mcp_proxy/httpx_client.py
+++ b/src/mcp_proxy/httpx_client.py
@@ -157,8 +157,12 @@ def custom_httpx_client(  # noqa: C901
                 if request_state.get("force_clear_session_id"):
                     logger.info("Cleared MCP session id suppression after receiving new session id")
                 request_state["force_clear_session_id"] = False
+                if request_state.get("force_reinit"):
+                    logger.info("Cleared re-init requirement after receiving new session id")
+                request_state["force_reinit"] = False
             if response.status_code == 404:
                 request_state["force_clear_session_id"] = True
+                request_state["force_reinit"] = True
                 logger.info(
                     "HTTP 404 for %s %s; will clear MCP session id on subsequent requests",
                     response.request.method,

--- a/src/mcp_proxy/httpx_client.py
+++ b/src/mcp_proxy/httpx_client.py
@@ -113,17 +113,17 @@ def custom_httpx_client(  # noqa: C901
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Response Headers: %s", dict(response.headers))
 
-        # Treat certain statuses as retryable to trigger outer reconnect/re-init logic.
-        retryable_statuses = {401, 404, 410, 503}
-        if response.status_code in retryable_statuses:
+        # Treat any 4xx and 503 as retryable to trigger outer reconnect/re-init logic.
+        status = response.status_code
+        if 400 <= status < 500 or status == 503:
             logger.warning(
                 "Retryable HTTP status %s for %s %s; raising to trigger reconnect",
-                response.status_code,
+                status,
                 response.request.method,
                 response.request.url,
             )
             raise httpx.HTTPStatusError(
-                f"Retryable HTTP status: {response.status_code}",
+                f"Retryable HTTP status: {status}",
                 request=response.request,
                 response=response,
             )

--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -176,22 +176,41 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         *,
         attempts: int,
         max_attempts: int,
+        detail: str | None = None,
     ) -> None:
         if hasattr(remote_app, "rebuild"):
+            if detail:
+                logger.warning(
+                    "%s timed out; rebuilding transport (%s/%s); %s",
+                    label,
+                    attempts,
+                    max_attempts - 1,
+                    detail,
+                )
+            else:
+                logger.warning(
+                    "%s timed out; rebuilding transport (%s/%s)",
+                    label,
+                    attempts,
+                    max_attempts - 1,
+                )
+            await remote_app.rebuild()  # type: ignore[attr-defined]
+            return
+        if detail:
             logger.warning(
-                "%s timed out; rebuilding transport (%s/%s)",
+                "%s timed out; re-initializing session (%s/%s); %s",
+                label,
+                attempts,
+                max_attempts - 1,
+                detail,
+            )
+        else:
+            logger.warning(
+                "%s timed out; re-initializing session (%s/%s)",
                 label,
                 attempts,
                 max_attempts - 1,
             )
-            await remote_app.rebuild()  # type: ignore[attr-defined]
-            return
-        logger.warning(
-            "%s timed out; re-initializing session (%s/%s)",
-            label,
-            attempts,
-            max_attempts - 1,
-        )
         await remote_app.initialize()
 
     def _is_retryable_status(status: int | None) -> bool:
@@ -248,6 +267,7 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
                     label,
                     attempts=attempts,
                     max_attempts=max_attempts,
+                    detail=_describe_last_post(),
                 )
                 await asyncio.sleep(backoff_s)
                 backoff_s = min(5.0, backoff_s * 2)
@@ -425,6 +445,7 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
                             f"CallTool {req.params.name}",
                             attempts=attempts,
                             max_attempts=max_attempts,
+                            detail=_describe_last_post(),
                         )
                         await asyncio.sleep(backoff_s)
                         backoff_s = min(5.0, backoff_s * 2)

--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -263,6 +263,7 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
                 max_attempts - 1,
             )
             try:
+                logger.info("%s rebuild invoking remote_app.rebuild() type=%s", label, type(remote_app).__name__)
                 await asyncio.wait_for(remote_app.rebuild(), timeout=5.0)  # type: ignore[attr-defined]
             except asyncio.TimeoutError:
                 logger.warning(
@@ -321,6 +322,7 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
                     max_attempts - 1,
                 )
             try:
+                logger.info("%s rebuild invoking remote_app.rebuild() type=%s", label, type(remote_app).__name__)
                 await asyncio.wait_for(remote_app.rebuild(), timeout=5.0)  # type: ignore[attr-defined]
             except asyncio.TimeoutError:
                 logger.warning(

--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -89,6 +89,8 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         *,
         label: str,
     ) -> t.Any:
+        if call_timeout_s is not None:
+            logger.debug("%s starting call; timeout=%.1fs", label, call_timeout_s)
         await _drain_error_queue()
 
         async def _run() -> t.Any:

--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -543,6 +543,7 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         async def _call_tool(req: types.CallToolRequest) -> types.ServerResult:
             attempts = 0
             backoff_s = 0.5
+            logger.info("CallTool request received; name=%s", req.params.name)
 
             def _retryable_status_in_error(err: BaseException) -> int | None:
                 for leaf in _iter_exceptions(err):

--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -3,6 +3,7 @@
 This server is created independent of any transport mechanism.
 """
 
+import asyncio
 import logging
 import typing as t
 
@@ -40,6 +41,97 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
     response = await remote_app.initialize()
     capabilities = response.capabilities
 
+    max_attempts = getattr(remote_app, "_retry_attempts", 0)
+    max_attempts = 1 + max(0, max_attempts)
+
+    semaphore = getattr(remote_app, "_proxy_semaphore", None)
+    if semaphore is None:
+        # Avoid thundering-herd behavior when Codex issues many concurrent reads.
+        semaphore = asyncio.Semaphore(getattr(remote_app, "_proxy_max_inflight", 8))
+        remote_app._proxy_semaphore = semaphore  # type: ignore[attr-defined]
+
+    def _is_retryable_status(status: int | None) -> bool:
+        if status is None:
+            return False
+        return 400 <= status < 500 or status == 503
+
+    def _session_error_in_exception(err: BaseException) -> bool:
+        for leaf in _iter_exceptions(err):
+            if isinstance(leaf, McpError):
+                code = getattr(leaf.error, "code", None)
+                msg = getattr(leaf.error, "message", "") or ""
+                if code == -32001:
+                    return True
+                if code == 32600 and "Session terminated" in msg:
+                    return True
+            text = str(leaf)
+            if "Session not found" in text or "-32001" in text:
+                return True
+            if "Session terminated" in text:
+                return True
+        return False
+
+    async def _call_remote(
+        label: str,
+        call: t.Callable[[], t.Awaitable[t.Any]],
+    ) -> t.Any:
+        attempts = 0
+        backoff_s = 0.5
+
+        while True:
+            try:
+                async with semaphore:
+                    return await call()
+            except httpx.HTTPStatusError as exc:
+                attempts += 1
+                status = exc.response.status_code if exc.response else None
+                if not _is_retryable_status(status) or attempts >= max_attempts:
+                    raise
+                logger.warning(
+                    "%s got HTTP %s; re-initializing session (%s/%s)",
+                    label,
+                    status,
+                    attempts,
+                    max_attempts - 1,
+                )
+                await remote_app.initialize()
+                await asyncio.sleep(backoff_s)
+                backoff_s = min(5.0, backoff_s * 2)
+                continue
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                attempts += 1
+                if attempts >= max_attempts:
+                    raise
+                logger.warning(
+                    "%s got network/timeout error; re-initializing session (%s/%s); error=%s",
+                    label,
+                    attempts,
+                    max_attempts - 1,
+                    exc,
+                )
+                await remote_app.initialize()
+                await asyncio.sleep(backoff_s)
+                backoff_s = min(5.0, backoff_s * 2)
+                continue
+            except Exception as exc:  # noqa: BLE001
+                if _session_error_in_exception(exc) and attempts + 1 < max_attempts:
+                    attempts += 1
+                    logger.warning(
+                        "%s got session error; re-initializing session (%s/%s)",
+                        label,
+                        attempts,
+                        max_attempts - 1,
+                    )
+                    await remote_app.initialize()
+                    await asyncio.sleep(backoff_s)
+                    backoff_s = min(5.0, backoff_s * 2)
+                    continue
+                raise
+
+    async def _call_remote_once(call: t.Callable[[], t.Awaitable[t.Any]]) -> t.Any:
+        async with semaphore:
+            return await call()
+
     logger.debug("Configuring proxied MCP server...")
     app: server.Server[object] = server.Server(name=response.serverInfo.name)
 
@@ -47,13 +139,16 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         logger.debug("Capabilities: adding Prompts...")
 
         async def _list_prompts(_: t.Any) -> types.ServerResult:  # noqa: ANN401
-            result = await remote_app.list_prompts()
+            result = await _call_remote("ListPrompts", remote_app.list_prompts)
             return types.ServerResult(result)
 
         app.request_handlers[types.ListPromptsRequest] = _list_prompts
 
         async def _get_prompt(req: types.GetPromptRequest) -> types.ServerResult:
-            result = await remote_app.get_prompt(req.params.name, req.params.arguments)
+            result = await _call_remote(
+                f"GetPrompt {req.params.name}",
+                lambda: remote_app.get_prompt(req.params.name, req.params.arguments),
+            )
             return types.ServerResult(result)
 
         app.request_handlers[types.GetPromptRequest] = _get_prompt
@@ -62,19 +157,22 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         logger.debug("Capabilities: adding Resources...")
 
         async def _list_resources(_: t.Any) -> types.ServerResult:  # noqa: ANN401
-            result = await remote_app.list_resources()
+            result = await _call_remote("ListResources", remote_app.list_resources)
             return types.ServerResult(result)
 
         app.request_handlers[types.ListResourcesRequest] = _list_resources
 
         async def _list_resource_templates(_: t.Any) -> types.ServerResult:  # noqa: ANN401
-            result = await remote_app.list_resource_templates()
+            result = await _call_remote("ListResourceTemplates", remote_app.list_resource_templates)
             return types.ServerResult(result)
 
         app.request_handlers[types.ListResourceTemplatesRequest] = _list_resource_templates
 
         async def _read_resource(req: types.ReadResourceRequest) -> types.ServerResult:
-            result = await remote_app.read_resource(req.params.uri)
+            result = await _call_remote(
+                f"ReadResource {req.params.uri}",
+                lambda: remote_app.read_resource(req.params.uri),
+            )
             return types.ServerResult(result)
 
         app.request_handlers[types.ReadResourceRequest] = _read_resource
@@ -83,7 +181,10 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         logger.debug("Capabilities: adding Logging...")
 
         async def _set_logging_level(req: types.SetLevelRequest) -> types.ServerResult:
-            await remote_app.set_logging_level(req.params.level)
+            await _call_remote(
+                f"SetLoggingLevel {req.params.level}",
+                lambda: remote_app.set_logging_level(req.params.level),
+            )
             return types.ServerResult(types.EmptyResult())
 
         app.request_handlers[types.SetLevelRequest] = _set_logging_level
@@ -92,13 +193,19 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         logger.debug("Capabilities: adding Resources...")
 
         async def _subscribe_resource(req: types.SubscribeRequest) -> types.ServerResult:
-            await remote_app.subscribe_resource(req.params.uri)
+            await _call_remote(
+                f"SubscribeResource {req.params.uri}",
+                lambda: remote_app.subscribe_resource(req.params.uri),
+            )
             return types.ServerResult(types.EmptyResult())
 
         app.request_handlers[types.SubscribeRequest] = _subscribe_resource
 
         async def _unsubscribe_resource(req: types.UnsubscribeRequest) -> types.ServerResult:
-            await remote_app.unsubscribe_resource(req.params.uri)
+            await _call_remote(
+                f"UnsubscribeResource {req.params.uri}",
+                lambda: remote_app.unsubscribe_resource(req.params.uri),
+            )
             return types.ServerResult(types.EmptyResult())
 
         app.request_handlers[types.UnsubscribeRequest] = _unsubscribe_resource
@@ -107,39 +214,14 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         logger.debug("Capabilities: adding Tools...")
 
         async def _list_tools(_: t.Any) -> types.ServerResult:  # noqa: ANN401
-            tools = await remote_app.list_tools()
+            tools = await _call_remote("ListTools", remote_app.list_tools)
             return types.ServerResult(tools)
 
         app.request_handlers[types.ListToolsRequest] = _list_tools
 
         async def _call_tool(req: types.CallToolRequest) -> types.ServerResult:
             attempts = 0
-            max_attempts = getattr(remote_app, "_retry_attempts", 0)
-            max_attempts = 1 + max(0, max_attempts)
-
-            def _is_retryable_status(status: int | None) -> bool:
-                if status is None:
-                    return False
-                return 400 <= status < 500 or status == 503
-
-            def _session_not_found_in_error(err: BaseException) -> bool:
-                for leaf in _iter_exceptions(err):
-                    if isinstance(leaf, McpError):
-                        code = getattr(leaf.error, "code", None)
-                        msg = getattr(leaf.error, "message", "") or ""
-                        # -32001: common upstream "Session not found"
-                        if code == -32001:
-                            return True
-                        # 32600: JSON-RPC Invalid Request; observed from some servers as "Session terminated"
-                        # Treat this as a terminal session signal and re-initialize.
-                        if code == 32600 and "Session terminated" in msg:
-                            return True
-                    text = str(leaf)
-                    if "Session not found" in text or "-32001" in text:
-                        return True
-                    if "Session terminated" in text:
-                        return True
-                return False
+            backoff_s = 0.5
 
             def _retryable_status_in_error(err: BaseException) -> int | None:
                 for leaf in _iter_exceptions(err):
@@ -165,9 +247,8 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
             try:
                 while attempts < max_attempts:
                     try:
-                        result = await remote_app.call_tool(
-                            req.params.name,
-                            (req.params.arguments or {}),
+                        result = await _call_remote_once(
+                            lambda: remote_app.call_tool(req.params.name, (req.params.arguments or {})),
                         )
                         if _is_session_error_result(result) and attempts + 1 < max_attempts:
                             attempts += 1
@@ -178,6 +259,8 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
                                 max_attempts - 1,
                             )
                             await remote_app.initialize()
+                            await asyncio.sleep(backoff_s)
+                            backoff_s = min(5.0, backoff_s * 2)
                             continue
                         return types.ServerResult(result)
                     except httpx.HTTPStatusError as exc:
@@ -193,6 +276,23 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
                             max_attempts - 1,
                         )
                         await remote_app.initialize()
+                        await asyncio.sleep(backoff_s)
+                        backoff_s = min(5.0, backoff_s * 2)
+                        continue
+                    except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                        attempts += 1
+                        if attempts >= max_attempts:
+                            raise
+                        logger.warning(
+                            "CallTool %s got network/timeout error; re-initializing session (%s/%s); error=%s",
+                            req.params.name,
+                            attempts,
+                            max_attempts - 1,
+                            exc,
+                        )
+                        await remote_app.initialize()
+                        await asyncio.sleep(backoff_s)
+                        backoff_s = min(5.0, backoff_s * 2)
                         continue
                     except Exception as exc:  # noqa: BLE001
                         status = _retryable_status_in_error(exc)
@@ -206,10 +306,12 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
                                 max_attempts - 1,
                             )
                             await remote_app.initialize()
+                            await asyncio.sleep(backoff_s)
+                            backoff_s = min(5.0, backoff_s * 2)
                             continue
 
                         # Handle JSON-RPC session errors that come back as 200 with an error payload
-                        if _session_not_found_in_error(exc) and attempts + 1 < max_attempts:
+                        if _session_error_in_exception(exc) and attempts + 1 < max_attempts:
                             attempts += 1
                             logger.warning(
                                 "CallTool %s got session error; re-initializing session (%s/%s)",
@@ -218,6 +320,8 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
                                 max_attempts - 1,
                             )
                             await remote_app.initialize()
+                            await asyncio.sleep(backoff_s)
+                            backoff_s = min(5.0, backoff_s * 2)
                             continue
                         raise
             except Exception as e:  # noqa: BLE001
@@ -240,9 +344,9 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
     app.notification_handlers[types.ProgressNotification] = _send_progress_notification
 
     async def _complete(req: types.CompleteRequest) -> types.ServerResult:
-        result = await remote_app.complete(
-            req.params.ref,
-            req.params.argument.model_dump(),
+        result = await _call_remote(
+            f"Complete {req.params.ref.type}/{req.params.ref.name}",
+            lambda: remote_app.complete(req.params.ref, req.params.argument.model_dump()),
         )
         return types.ServerResult(result)
 

--- a/src/mcp_proxy/sse_client.py
+++ b/src/mcp_proxy/sse_client.py
@@ -55,6 +55,18 @@ async def run_sse_client(
                         app.create_initialization_options(),
                     )
                 return
+        except httpx.HTTPStatusError as exc:
+            attempts += 1
+            if attempts >= max_attempts:
+                raise
+            logger.warning(
+                "Remote SSE HTTP status %s; forcing re-init (%s/%s); url=%s",
+                exc.response.status_code if exc.response else "unknown",
+                attempts,
+                max_attempts - 1,
+                url,
+            )
+            await asyncio.sleep(0.5)
         except Exception as exc:  # noqa: BLE001
             attempts += 1
             if attempts >= max_attempts:

--- a/src/mcp_proxy/sse_client.py
+++ b/src/mcp_proxy/sse_client.py
@@ -1,5 +1,7 @@
 """Create a local server that proxies requests to a remote server over SSE."""
 
+import asyncio
+import logging
 from functools import partial
 from typing import Any
 
@@ -11,12 +13,15 @@ from mcp.server.stdio import stdio_server
 from .httpx_client import custom_httpx_client
 from .proxy_server import create_proxy_server
 
+logger = logging.getLogger(__name__)
+
 
 async def run_sse_client(
     url: str,
     headers: dict[str, Any] | None = None,
     auth: httpx.Auth | None = None,
     verify_ssl: bool | str | None = None,
+    retry_attempts: int = 0,
 ) -> None:
     """Run the SSE client.
 
@@ -26,20 +31,39 @@ async def run_sse_client(
         auth: Optional authentication for the HTTP client.
         verify_ssl: Control SSL verification. Use False to disable
             or a path to a certificate bundle.
+        retry_attempts: Number of retries for the remote MCP connection on failure.
     """
-    async with (
-        sse_client(
-            url=url,
-            headers=headers,
-            auth=auth,
-            httpx_client_factory=partial(custom_httpx_client, verify_ssl=verify_ssl),
-        ) as streams,
-        ClientSession(*streams) as session,
-    ):
-        app = await create_proxy_server(session)
-        async with stdio_server() as (read_stream, write_stream):
-            await app.run(
-                read_stream,
-                write_stream,
-                app.create_initialization_options(),
+    attempts = 0
+    max_attempts = 1 + max(0, retry_attempts)
+
+    while attempts < max_attempts:
+        try:
+            async with (
+                sse_client(
+                    url=url,
+                    headers=headers,
+                    auth=auth,
+                    httpx_client_factory=partial(custom_httpx_client, verify_ssl=verify_ssl),
+                ) as streams,
+                ClientSession(*streams) as session,
+            ):
+                app = await create_proxy_server(session)
+                async with stdio_server() as (read_stream, write_stream):
+                    await app.run(
+                        read_stream,
+                        write_stream,
+                        app.create_initialization_options(),
+                    )
+                return
+        except Exception as exc:  # noqa: BLE001
+            attempts += 1
+            if attempts >= max_attempts:
+                raise
+            logger.warning(
+                "Remote SSE failure; attempt %s/%s; url=%s; error=%s",
+                attempts,
+                max_attempts - 1,
+                url,
+                exc,
             )
+            await asyncio.sleep(0.5)

--- a/src/mcp_proxy/sse_client.py
+++ b/src/mcp_proxy/sse_client.py
@@ -47,6 +47,7 @@ async def run_sse_client(
                 ) as streams,
                 ClientSession(*streams) as session,
             ):
+                session._retry_attempts = retry_attempts  # type: ignore[attr-defined]
                 app = await create_proxy_server(session)
                 async with stdio_server() as (read_stream, write_stream):
                     await app.run(

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -55,6 +55,18 @@ async def run_streamablehttp_client(
                         app.create_initialization_options(),
                     )
                 return
+        except httpx.HTTPStatusError as exc:
+            attempts += 1
+            if attempts >= max_attempts:
+                raise
+            logger.warning(
+                "Remote StreamableHTTP HTTP status %s; forcing re-init (%s/%s); url=%s",
+                exc.response.status_code if exc.response else "unknown",
+                attempts,
+                max_attempts - 1,
+                url,
+            )
+            await asyncio.sleep(0.5)
         except Exception as exc:  # noqa: BLE001
             attempts += 1
             if attempts >= max_attempts:

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 import logging
+import sys
 from functools import partial
 from typing import Any
 
@@ -15,6 +16,49 @@ from .httpx_client import custom_httpx_client
 from .proxy_server import create_proxy_server
 
 logger = logging.getLogger(__name__)
+
+try:
+    _BaseExceptionGroup: type[BaseException] | tuple[type[BaseException], ...] = BaseExceptionGroup  # type: ignore[name-defined]
+except NameError:  # pragma: no cover (Python < 3.11)
+    _BaseExceptionGroup = ()
+
+
+def _stdin_is_closed() -> bool:
+    try:
+        return sys.stdin is None or sys.stdin.closed
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _is_closed_stdio_error(exc: BaseException) -> bool:
+    # If Codex terminates a tool call, it may close the stdio pipes immediately.
+    # The MCP stdio server can raise `ValueError: I/O operation on closed file` on startup.
+    # Treat that as a clean shutdown signal rather than a retryable remote failure.
+    stack: list[BaseException] = [exc]
+    seen: set[int] = set()
+
+    while stack:
+        current = stack.pop()
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+
+        if isinstance(current, ValueError) and "I/O operation on closed file" in str(current):
+            return True
+
+        # Python 3.11+ ExceptionGroup/BaseExceptionGroup
+        if _BaseExceptionGroup and isinstance(current, _BaseExceptionGroup):  # type: ignore[arg-type]
+            try:
+                stack.extend(list(getattr(current, "exceptions")))  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                pass
+
+        for next_exc in (getattr(current, "__cause__", None), getattr(current, "__context__", None)):
+            if isinstance(next_exc, BaseException):
+                stack.append(next_exc)
+
+    return False
 
 
 async def run_streamablehttp_client(
@@ -38,6 +82,12 @@ async def run_streamablehttp_client(
     max_attempts = 1 + max(0, retry_attempts)
 
     while attempts < max_attempts:
+        # If our stdio is already closed, there's nothing useful we can do.
+        # Exiting quietly avoids noisy ExceptionGroup tracebacks.
+        if _stdin_is_closed():
+            logger.debug("stdio already closed; exiting StreamableHTTP client loop")
+            return
+
         try:
             stream_kwargs: dict[str, Any] = {
                 "url": url,
@@ -72,13 +122,22 @@ async def run_streamablehttp_client(
                 # propagate retry budget to downstream handlers (used in CallTool wrapper)
                 session._retry_attempts = retry_attempts  # type: ignore[attr-defined]
                 app = await create_proxy_server(session)
-                async with stdio_server() as (read_stream, write_stream):
-                    await app.run(
-                        read_stream,
-                        write_stream,
-                        app.create_initialization_options(),
-                    )
+                try:
+                    async with stdio_server() as (read_stream, write_stream):
+                        await app.run(
+                            read_stream,
+                            write_stream,
+                            app.create_initialization_options(),
+                        )
+                except ValueError as exc:
+                    if _is_closed_stdio_error(exc) or _stdin_is_closed():
+                        logger.debug("stdio closed during startup; exiting")
+                        return
+                    raise
                 return
+        except asyncio.CancelledError:
+            # Cooperative shutdown (Codex timing out / cancelling tool call).
+            raise
         except httpx.HTTPStatusError as exc:
             attempts += 1
             if attempts >= max_attempts:
@@ -92,6 +151,9 @@ async def run_streamablehttp_client(
             )
             await asyncio.sleep(0.5)
         except Exception as exc:  # noqa: BLE001
+            if _is_closed_stdio_error(exc) or _stdin_is_closed():
+                logger.debug("stdio closed; exiting")
+                return
             attempts += 1
             if attempts >= max_attempts:
                 raise

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -126,13 +126,17 @@ class _ReconnectableSession:
         return session
 
     async def open(self) -> ClientSession:
+        logger.info("streamablehttp rebuild: open requested")
         async with self._lock:
+            logger.info("streamablehttp rebuild: open lock acquired")
             if self._session is None:
                 return await self._open_session()
             return self._session
 
     async def rebuild(self) -> ClientSession:
+        logger.info("streamablehttp rebuild: rebuild requested")
         async with self._lock:
+            logger.info("streamablehttp rebuild: rebuild lock acquired")
             await self._close_locked()
             return await self._open_session()
 

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -121,8 +121,12 @@ class _ReconnectableSession:
     async def _close_locked(self) -> None:
         if self._stack is not None:
             logger.info("streamablehttp rebuild: closing existing transport")
-            await self._stack.aclose()
-            logger.info("streamablehttp rebuild: existing transport closed")
+            close_start = time.monotonic()
+            try:
+                await self._stack.aclose()
+            finally:
+                elapsed_ms = (time.monotonic() - close_start) * 1000
+                logger.info("streamablehttp rebuild: existing transport close returned (%.0fms)", elapsed_ms)
         self._stack = None
         self._session = None
 

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -153,6 +153,7 @@ async def run_streamablehttp_client(
             return
 
         try:
+            request_state: dict[str, Any] = {}
             stream_kwargs: dict[str, Any] = {
                 "url": url,
                 "headers": headers,
@@ -161,6 +162,7 @@ async def run_streamablehttp_client(
                     custom_httpx_client,
                     verify_ssl=verify_ssl,
                     error_queue=error_queue,
+                    request_state=request_state,
                 ),
                 # Don't terminate the whole proxy if the server->client GET stream drops.
                 # QuickMemory (and some other servers) can intermittently fail the GET stream
@@ -188,6 +190,7 @@ async def run_streamablehttp_client(
             reconnectable._retry_attempts = retry_attempts  # type: ignore[attr-defined]
             reconnectable._http_error_queue = error_queue  # type: ignore[attr-defined]
             reconnectable._proxy_call_timeout_s = call_timeout_s  # type: ignore[attr-defined]
+            reconnectable._http_request_state = request_state  # type: ignore[attr-defined]
             app = await create_proxy_server(reconnectable)
             try:
                 async with stdio_server() as (read_stream, write_stream):

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -65,7 +65,7 @@ def _is_closed_stdio_error(exc: BaseException) -> bool:
 def _parse_call_timeout_s() -> float | None:
     raw = os.getenv("MCP_PROXY_CALL_TIMEOUT_S")
     if raw is None:
-        return 20.0
+        return 15.0
     try:
         value = float(raw)
     except ValueError:
@@ -102,7 +102,7 @@ async def run_streamablehttp_client(
         # If our stdio is already closed, there's nothing useful we can do.
         # Exiting quietly avoids noisy ExceptionGroup tracebacks.
         if _stdin_is_closed():
-            logger.debug("stdio already closed; exiting StreamableHTTP client loop")
+            logger.info("stdio already closed; exiting (caller likely cancelled/timeout)")
             return
 
         try:
@@ -154,7 +154,7 @@ async def run_streamablehttp_client(
                         )
                 except ValueError as exc:
                     if _is_closed_stdio_error(exc) or _stdin_is_closed():
-                        logger.debug("stdio closed during startup; exiting")
+                        logger.info("stdio closed during startup; exiting (caller likely cancelled/timeout)")
                         return
                     raise
                 return
@@ -188,7 +188,7 @@ async def run_streamablehttp_client(
             await asyncio.sleep(0.5)
         except Exception as exc:  # noqa: BLE001
             if _is_closed_stdio_error(exc) or _stdin_is_closed():
-                logger.debug("stdio closed; exiting")
+                logger.info("stdio closed; exiting (caller likely cancelled/timeout)")
                 return
             attempts += 1
             if attempts >= max_attempts:

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -1,5 +1,7 @@
 """Create a local server that proxies requests to a remote server over SSE."""
 
+import asyncio
+import logging
 from functools import partial
 from typing import Any
 
@@ -11,12 +13,15 @@ from mcp.server.stdio import stdio_server
 from .httpx_client import custom_httpx_client
 from .proxy_server import create_proxy_server
 
+logger = logging.getLogger(__name__)
+
 
 async def run_streamablehttp_client(
     url: str,
     headers: dict[str, Any] | None = None,
     auth: httpx.Auth | None = None,
     verify_ssl: bool | str | None = None,
+    retry_attempts: int = 0,
 ) -> None:
     """Run the StreamableHTTP client.
 
@@ -26,20 +31,39 @@ async def run_streamablehttp_client(
         auth: Optional authentication for the HTTP client.
         verify_ssl: Control SSL verification. Use False to disable
             or a path to a certificate bundle.
+        retry_attempts: Number of retries for the remote MCP connection on failure.
     """
-    async with (
-        streamablehttp_client(
-            url=url,
-            headers=headers,
-            auth=auth,
-            httpx_client_factory=partial(custom_httpx_client, verify_ssl=verify_ssl),
-        ) as (read, write, _),
-        ClientSession(read, write) as session,
-    ):
-        app = await create_proxy_server(session)
-        async with stdio_server() as (read_stream, write_stream):
-            await app.run(
-                read_stream,
-                write_stream,
-                app.create_initialization_options(),
+    attempts = 0
+    max_attempts = 1 + max(0, retry_attempts)
+
+    while attempts < max_attempts:
+        try:
+            async with (
+                streamablehttp_client(
+                    url=url,
+                    headers=headers,
+                    auth=auth,
+                    httpx_client_factory=partial(custom_httpx_client, verify_ssl=verify_ssl),
+                ) as (read, write, _),
+                ClientSession(read, write) as session,
+            ):
+                app = await create_proxy_server(session)
+                async with stdio_server() as (read_stream, write_stream):
+                    await app.run(
+                        read_stream,
+                        write_stream,
+                        app.create_initialization_options(),
+                    )
+                return
+        except Exception as exc:  # noqa: BLE001
+            attempts += 1
+            if attempts >= max_attempts:
+                raise
+            logger.warning(
+                "Remote StreamableHTTP failure; attempt %s/%s; url=%s; error=%s",
+                attempts,
+                max_attempts - 1,
+                url,
+                exc,
             )
+            await asyncio.sleep(0.5)

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -44,6 +44,11 @@ async def run_streamablehttp_client(
                 "headers": headers,
                 "auth": auth,
                 "httpx_client_factory": partial(custom_httpx_client, verify_ssl=verify_ssl),
+                # Don't terminate the whole proxy if the server->client GET stream drops.
+                # QuickMemory (and some other servers) can intermittently fail the GET stream
+                # while still accepting request/response POSTs. Exiting here causes Codex to see
+                # `tools/call failed: Transport closed`.
+                "terminate_on_close": False,
             }
 
             # Newer MCP Python SDKs accept reconnect_attempts; older ones don't.

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -144,6 +144,15 @@ async def run_streamablehttp_client(
     max_attempts = 1 + max(0, retry_attempts)
     error_queue: asyncio.Queue[httpx.HTTPStatusError] = asyncio.Queue(maxsize=32)
     call_timeout_s = _parse_call_timeout_s()
+    if call_timeout_s is None:
+        logger.info("Per-call timeout disabled (MCP_PROXY_CALL_TIMEOUT_S<=0); retries depend on other errors")
+    else:
+        logger.info(
+            "Per-call timeout set to %.1fs (MCP_PROXY_CALL_TIMEOUT_S); retry attempts=%s; url=%s",
+            call_timeout_s,
+            retry_attempts,
+            url,
+        )
 
     while attempts < max_attempts:
         # If our stdio is already closed, there's nothing useful we can do.

--- a/tests/test_cli_arguments.py
+++ b/tests/test_cli_arguments.py
@@ -45,6 +45,25 @@ def test_verify_ssl_cli_no_verify_alias(parser: ArgumentParser) -> None:
     assert _normalize_verify_ssl(args.verify_ssl) is False
 
 
+def test_retry_remote_default_off(parser: ArgumentParser) -> None:
+    """Retry is opt-in; defaults to False."""
+    args = parser.parse_args(["https://example.com"])
+    assert args.retry_remote is False
+
+
+def test_retry_remote_flag_on(parser: ArgumentParser) -> None:
+    """Retry flag enables single retry."""
+    args = parser.parse_args(["--retry-remote", "https://example.com"])
+    assert args.retry_remote is True
+
+
+def test_remote_retries_count(parser: ArgumentParser) -> None:
+    """Explicit retry count parsed correctly."""
+    args = parser.parse_args(["--remote-retries", "3", "https://example.com"])
+    assert args.remote_retries == 3
+    assert args.retry_remote is False  # independent of count flag
+
+
 @patch("mcp_proxy.httpx_client.httpx.AsyncClient")
 def test_custom_httpx_client_disable_ssl(mock_async_client: Mock) -> None:
     """custom_httpx_client passes verify=False to httpx when disabled."""

--- a/tests/test_httpx_client.py
+++ b/tests/test_httpx_client.py
@@ -1,0 +1,41 @@
+"""Tests for custom httpx client retryable status handling."""
+
+from __future__ import annotations
+
+import pytest
+import httpx
+
+from mcp_proxy.httpx_client import custom_httpx_client
+
+
+@pytest.mark.asyncio
+async def test_retryable_status_raises_http_status_error() -> None:
+    """Retryable HTTP status codes should raise to trigger reconnect logic."""
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, request=request, json={"error": "not found"})
+
+    transport = httpx.MockTransport(handler)
+
+    client = custom_httpx_client()
+    client._transport = transport  # inject mock transport
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.get("http://localhost/mcp")
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_status_passes() -> None:
+    """200 responses should not raise."""
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, request=request, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+
+    client = custom_httpx_client()
+    client._transport = transport
+
+    resp = await client.get("http://localhost/mcp")
+    assert resp.status_code == 200
+    await client.aclose()

--- a/tests/test_proxy_server.py
+++ b/tests/test_proxy_server.py
@@ -372,6 +372,7 @@ class _TimeoutRemoteApp:
         self._proxy_call_timeout_s = 0.01
         self.call_count = 0
         self.init_count = 0
+        self.rebuild_count = 0
 
     async def initialize(self):
         self.init_count += 1
@@ -397,6 +398,9 @@ class _TimeoutRemoteApp:
                 ),
             ],
         )
+
+    async def rebuild(self):
+        self.rebuild_count += 1
 
     async def call_tool(self, name: str, arguments: dict[str, t.Any]):
         self.call_count += 1
@@ -457,7 +461,8 @@ async def test_call_tool_retries_on_call_timeout() -> None:
 
     assert not result.isError
     assert remote.call_count == 2
-    assert remote.init_count == 2
+    assert remote.init_count == 1
+    assert remote.rebuild_count == 1
 
 @pytest.fixture
 def server_can_list_resources(server: Server[object], resource: types.Resource) -> Server[object]:

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -31,8 +31,10 @@ async def dummy_stdio_server() -> AsyncIterator[tuple[Any, Any]]:
 
 @asynccontextmanager
 async def dummy_client_session(*_: Any, **__: Any) -> AsyncIterator[object]:
-    """Yield a placeholder client session."""
-    yield object()
+    """Yield a placeholder client session with mutable attributes."""
+    class _Session:
+        pass
+    yield _Session()
 
 
 def make_fail_then_success_cm():

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -1,0 +1,134 @@
+"""Retry behavior tests for SSE and StreamableHTTP clients."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from mcp_proxy.sse_client import run_sse_client
+from mcp_proxy.streamablehttp_client import run_streamablehttp_client
+
+
+class DummyApp:
+    """Minimal proxy app stub."""
+
+    async def run(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+        return None
+
+    def create_initialization_options(self) -> None:  # noqa: D401
+        return None
+
+
+@asynccontextmanager
+async def dummy_stdio_server() -> AsyncIterator[tuple[Any, Any]]:
+    """Yield placeholder stdio streams."""
+    yield ("r", "w")
+
+
+@asynccontextmanager
+async def dummy_client_session(*_: Any, **__: Any) -> AsyncIterator[object]:
+    """Yield a placeholder client session."""
+    yield object()
+
+
+def make_fail_then_success_cm():
+    """Return a context manager that fails once then yields streams."""
+    state = {"calls": 0}
+
+    @asynccontextmanager
+    async def _cm(*_: Any, **__: Any) -> AsyncIterator[tuple[Any, Any, Any]]:
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise RuntimeError("boom")
+        yield ("r", "w", None)
+
+    return _cm
+
+
+def make_always_fail_cm():
+    """Return a context manager that always raises."""
+
+    @asynccontextmanager
+    async def _cm(*_: Any, **__: Any) -> AsyncIterator[tuple[Any, Any, Any]]:
+        raise RuntimeError("still broken")
+        yield  # pragma: no cover
+
+    return _cm
+
+
+@pytest.mark.asyncio
+async def test_streamable_retry_succeeds_after_one_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should retry and succeed on second attempt when enabled."""
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.streamablehttp_client", make_fail_then_success_cm())
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.stdio_server", dummy_stdio_server)
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.create_proxy_server", AsyncMock(return_value=DummyApp()))
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.ClientSession", dummy_client_session)
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.asyncio.sleep", AsyncMock())
+
+    await run_streamablehttp_client(
+        url="http://example/mcp",
+        headers=None,
+        auth=None,
+        verify_ssl=None,
+        retry_attempts=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_streamable_retry_respects_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stops after configured retries and raises."""
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.streamablehttp_client", make_always_fail_cm())
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.stdio_server", dummy_stdio_server)
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.create_proxy_server", AsyncMock(return_value=DummyApp()))
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.ClientSession", dummy_client_session)
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.asyncio.sleep", AsyncMock())
+
+    with pytest.raises(RuntimeError):
+        await run_streamablehttp_client(
+            url="http://example/mcp",
+            headers=None,
+            auth=None,
+            verify_ssl=None,
+            retry_attempts=2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_sse_retry_succeeds_after_one_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SSE retry succeeds on second attempt."""
+    monkeypatch.setattr("mcp_proxy.sse_client.sse_client", make_fail_then_success_cm())
+    monkeypatch.setattr("mcp_proxy.sse_client.stdio_server", dummy_stdio_server)
+    monkeypatch.setattr("mcp_proxy.sse_client.create_proxy_server", AsyncMock(return_value=DummyApp()))
+    monkeypatch.setattr("mcp_proxy.sse_client.ClientSession", dummy_client_session)
+    monkeypatch.setattr("mcp_proxy.sse_client.asyncio.sleep", AsyncMock())
+
+    await run_sse_client(
+        url="http://example/sse",
+        headers=None,
+        auth=None,
+        verify_ssl=None,
+        retry_attempts=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sse_retry_respects_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SSE retry stops after configured attempts."""
+    monkeypatch.setattr("mcp_proxy.sse_client.sse_client", make_always_fail_cm())
+    monkeypatch.setattr("mcp_proxy.sse_client.stdio_server", dummy_stdio_server)
+    monkeypatch.setattr("mcp_proxy.sse_client.create_proxy_server", AsyncMock(return_value=DummyApp()))
+    monkeypatch.setattr("mcp_proxy.sse_client.ClientSession", dummy_client_session)
+    monkeypatch.setattr("mcp_proxy.sse_client.asyncio.sleep", AsyncMock())
+
+    with pytest.raises(RuntimeError):
+        await run_sse_client(
+            url="http://example/sse",
+            headers=None,
+            auth=None,
+            verify_ssl=None,
+            retry_attempts=2,
+        )

--- a/tests/test_stream_clients_reinit.py
+++ b/tests/test_stream_clients_reinit.py
@@ -1,0 +1,141 @@
+"""Retry/re-init behavior for streamable HTTP and SSE clients on HTTP status errors."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+from mcp_proxy.streamablehttp_client import run_streamablehttp_client
+from mcp_proxy.sse_client import run_sse_client
+
+
+class DummyApp:
+    """Minimal proxy app stub."""
+
+    async def run(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+        return None
+
+    def create_initialization_options(self) -> None:  # noqa: D401
+        return None
+
+
+@asynccontextmanager
+async def dummy_stdio_server() -> AsyncIterator[tuple[Any, Any]]:
+    """Yield placeholder stdio streams."""
+    yield ("r", "w")
+
+
+def make_http_status_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("GET", "http://example/mcp")
+    resp = httpx.Response(status, request=req)
+    return httpx.HTTPStatusError(f"status {status}", request=req, response=resp)
+
+
+def make_fail_then_pass_cm(status: int):
+    state = {"called": False}
+
+    @asynccontextmanager
+    async def _cm(*_: Any, **__: Any) -> AsyncIterator[tuple[Any, Any, Any]]:
+        if not state["called"]:
+            state["called"] = True
+            raise make_http_status_error(status)
+        yield ("r", "w", None)
+
+    return _cm
+
+
+def make_always_fail_cm(status: int):
+
+    @asynccontextmanager
+    async def _cm(*_: Any, **__: Any) -> AsyncIterator[tuple[Any, Any, Any]]:
+        raise make_http_status_error(status)
+        yield ("r", "w", None)  # pragma: no cover
+
+    return _cm
+
+
+@pytest.mark.asyncio
+async def test_streamable_reinit_on_http_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """StreamableHTTP client should retry/re-init on retryable HTTP status."""
+    monkeypatch.setattr(
+        "mcp_proxy.streamablehttp_client.streamablehttp_client",
+        make_fail_then_pass_cm(404),
+    )
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.stdio_server", dummy_stdio_server)
+    async def _create_proxy(_s: Any) -> DummyApp:
+        return DummyApp()
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.create_proxy_server", _create_proxy)
+    @asynccontextmanager
+    async def _client_session(*_: Any) -> AsyncIterator[Any]:
+        yield DummyApp()
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.ClientSession", _client_session)
+    async def _sleep(_: float) -> None:  # noqa: D401
+        return None
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.asyncio.sleep", _sleep)
+
+    await run_streamablehttp_client(
+        url="http://example/mcp",
+        headers=None,
+        auth=None,
+        verify_ssl=None,
+        retry_attempts=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_streamable_respects_retry_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """StreamableHTTP stops after exceeding retry budget."""
+    monkeypatch.setattr(
+        "mcp_proxy.streamablehttp_client.streamablehttp_client",
+        make_always_fail_cm(503),
+    )
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.stdio_server", dummy_stdio_server)
+    async def _create_proxy(_s: Any) -> DummyApp:
+        return DummyApp()
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.create_proxy_server", _create_proxy)
+    @asynccontextmanager
+    async def _client_session(*_: Any) -> AsyncIterator[Any]:
+        yield DummyApp()
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.ClientSession", _client_session)
+    async def _sleep(_: float) -> None:  # noqa: D401
+        return None
+    monkeypatch.setattr("mcp_proxy.streamablehttp_client.asyncio.sleep", _sleep)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await run_streamablehttp_client(
+            url="http://example/mcp",
+            headers=None,
+            auth=None,
+            verify_ssl=None,
+            retry_attempts=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_sse_reinit_on_http_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SSE client should retry/re-init on retryable HTTP status."""
+    monkeypatch.setattr(
+        "mcp_proxy.sse_client.sse_client",
+        make_fail_then_pass_cm(404),
+    )
+    monkeypatch.setattr("mcp_proxy.sse_client.stdio_server", dummy_stdio_server)
+    async def _create_proxy(_s: Any) -> DummyApp:
+        return DummyApp()
+    monkeypatch.setattr("mcp_proxy.sse_client.create_proxy_server", _create_proxy)
+    @asynccontextmanager
+    async def _client_session(*_: Any) -> AsyncIterator[Any]:
+        yield DummyApp()
+    monkeypatch.setattr("mcp_proxy.sse_client.ClientSession", _client_session)
+    async def _sleep(_: float) -> None:  # noqa: D401
+        return None
+    monkeypatch.setattr("mcp_proxy.sse_client.asyncio.sleep", _sleep)
+
+    await run_sse_client(
+        url="http://example/sse",
+        headers=None,
+        auth=None,
+        verify_ssl=None,
+        retry_attempts=1,
+    )

--- a/tests/test_stream_clients_reinit.py
+++ b/tests/test_stream_clients_reinit.py
@@ -96,7 +96,9 @@ async def test_streamable_omits_reconnect_attempts_when_not_supported(
         headers: dict[str, Any] | None = None,
         auth: Any | None = None,
         httpx_client_factory: Any | None = None,
+        terminate_on_close: bool = True,
     ) -> AsyncIterator[tuple[Any, Any, Any]]:
+        assert terminate_on_close is False
         _ = (url, headers, auth, httpx_client_factory)
         yield ("r", "w", None)
 


### PR DESCRIPTION
## Summary\n- Clear MCP-Session-Id after HTTP 404 and force re-initialize before the next call.\n- Add lock-acquire timeout/logs for StreamableHTTP rebuild/open/close to prevent silent hangs.\n- Add deeper telemetry to correlate SSE/requests (optional but helpful for diagnosing reconnect issues).\n- Document session re-init on 404 in README.\n\n## Testing\n- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0
rootdir: /mnt/e/sandbox/mcp-proxy
configfile: pyproject.toml
plugins: anyio-4.11.0, asyncio-1.2.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 107 items

tests/test_cli_arguments.py .........                                    [  8%]
tests/test_config_loader.py ............                                 [ 19%]
tests/test_httpx_client.py ......                                        [ 25%]
tests/test_mcp_server.py ...............                                 [ 39%]
tests/test_proxy_server.py ............................................. [ 81%]
.........                                                                [ 89%]
tests/test_retries.py .......                                            [ 96%]
tests/test_stream_clients_reinit.py ....                                 [100%]

============================= 107 passed in 19.05s =============================