### PR TITLE
feat: make json_response configurable via --json-response flag

### DIFF
--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -243,6 +243,14 @@ def _add_arguments_to_parser(parser: argparse.ArgumentParser) -> None:
         default=False,
     )
     mcp_server_group.add_argument(
+        "--json-response",
+        action=argparse.BooleanOptionalAction,
+        help="Use JSON responses instead of SSE streams for the Streamable HTTP transport. "
+        "When enabled, only application/json Accept header is required. "
+        "When disabled (default), the server responds with SSE streams per the MCP specification.",
+        default=False,
+    )
+    mcp_server_group.add_argument(
         "--sse-port",
         type=int,
         default=0,
@@ -440,6 +448,7 @@ def _create_mcp_settings(args_parsed: argparse.Namespace) -> MCPServerSettings:
         bind_host=args_parsed.host if args_parsed.host is not None else args_parsed.sse_host,
         port=args_parsed.port if args_parsed.port is not None else args_parsed.sse_port,
         stateless=args_parsed.stateless,
+        json_response=args_parsed.json_response,
         allow_origins=args_parsed.allow_origin if len(args_parsed.allow_origin) > 0 else None,
         expose_headers=expose_headers,
         log_level="DEBUG" if args_parsed.debug else args_parsed.log_level,

--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -39,6 +39,7 @@ class MCPServerSettings:
     bind_host: str
     port: int
     stateless: bool = False
+    json_response: bool = False
     allow_origins: list[str] | None = None
     expose_headers: list[str] = field(default_factory=_default_expose_headers)
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
@@ -77,18 +78,20 @@ def create_single_instance_routes(
     mcp_server_instance: MCPServerSDK[object],
     *,
     stateless_instance: bool,
+    json_response_instance: bool,
 ) -> tuple[list[BaseRoute], StreamableHTTPSessionManager]:  # Return the manager itself
     """Create Starlette routes and the HTTP session manager for a single MCP server instance."""
     logger.debug(
-        "Creating routes for a single MCP server instance (stateless: %s)",
+        "Creating routes for a single MCP server instance (stateless: %s, json_response: %s)",
         stateless_instance,
+        json_response_instance,
     )
 
     sse_transport = SseServerTransport("/messages/")
     http_session_manager = StreamableHTTPSessionManager(
         app=mcp_server_instance,
         event_store=None,
-        json_response=True,
+        json_response=json_response_instance,
         stateless=stateless_instance,
     )
 
@@ -181,6 +184,7 @@ async def run_mcp_server(
             instance_routes, http_manager = create_single_instance_routes(
                 proxy,
                 stateless_instance=mcp_settings.stateless,
+                json_response_instance=mcp_settings.json_response,
             )
             await stack.enter_async_context(http_manager.run())  # Manage lifespan by calling run()
             all_routes.extend(instance_routes)
@@ -201,6 +205,7 @@ async def run_mcp_server(
             instance_routes_named, http_manager_named = create_single_instance_routes(
                 proxy_named,
                 stateless_instance=mcp_settings.stateless,
+                json_response_instance=mcp_settings.json_response,
             )
             await stack.enter_async_context(
                 http_manager_named.run(),


### PR DESCRIPTION
## Problem

The `json_response` parameter passed to `StreamableHTTPSessionManager` is hardcoded to `True` in `mcp_server.py`. This forces the Streamable HTTP transport (`/mcp` endpoint) to always respond with plain JSON, which prevents SSE-based clients from receiving proper Server-Sent Events responses.

This breaks compatibility with clients that use the `/mcp` endpoint with `Accept: text/event-stream`, such as:
- **Anthropic's MCP proxy** (used by Claude.ai for remote MCP integrations)
- Any MCP client that expects SSE responses on the Streamable HTTP transport per the [MCP specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http)

### Reproduction

1. Start mcp-proxy with a stdio server
2. Send a POST to `/mcp` with `Accept: text/event-stream`
3. Get `406 Not Acceptable: Client must accept application/json`
4. The `/sse` endpoint works, but `/mcp` should also support SSE responses per the spec

## Solution

Make `json_response` configurable via a `--json-response / --no-json-response` CLI flag, defaulting to `False` (SSE responses enabled, spec-compliant).

### Changes

- Add `--json-response` / `--no-json-response` CLI argument (default: `False`)
- Add `json_response` field to `MCPServerSettings`
- Pass the setting through to `StreamableHTTPSessionManager`

### Breaking change note

The default behavior changes from JSON-only to SSE-capable responses on `/mcp`. Users who depend on the previous JSON-only behavior can pass `--json-response` to restore it.

## Testing

Tested with:
- Claude.ai remote MCP integration (Anthropic proxy → mcp-proxy → mcp-wordpress)
- Direct curl with `Accept: text/event-stream` and `Accept: application/json`
- Both `/sse` and `/mcp` endpoints verified working