### PR TITLE
feat: add optional Bearer token authentication

### DIFF
--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -273,6 +273,17 @@ def _add_arguments_to_parser(parser: argparse.ArgumentParser) -> None:
             "Defaults to 'Mcp-Session-Id'. Can be used multiple times."
         ),
     )
+    mcp_server_group.add_argument(
+        "--auth-bearer-token",
+        default=None,
+        metavar="TOKEN",
+        help=(
+            "Require an `Authorization: Bearer <token>` header on all routes "
+            "except `/status`. If omitted, falls back to the "
+            "`MCP_PROXY_AUTH_TOKEN` environment variable. When neither is set, "
+            "authentication is disabled (default)."
+        ),
+    )
 
 
 def _setup_logging(*, level: str, debug: bool) -> logging.Logger:
@@ -436,6 +447,9 @@ def _create_mcp_settings(args_parsed: argparse.Namespace) -> MCPServerSettings:
         if not args_parsed.expose_headers
         else list(args_parsed.expose_headers)
     )
+    auth_bearer_token = args_parsed.auth_bearer_token or os.getenv(
+        "MCP_PROXY_AUTH_TOKEN",
+    )
     return MCPServerSettings(
         bind_host=args_parsed.host if args_parsed.host is not None else args_parsed.sse_host,
         port=args_parsed.port if args_parsed.port is not None else args_parsed.sse_port,
@@ -443,6 +457,7 @@ def _create_mcp_settings(args_parsed: argparse.Namespace) -> MCPServerSettings:
         allow_origins=args_parsed.allow_origin if len(args_parsed.allow_origin) > 0 else None,
         expose_headers=expose_headers,
         log_level="DEBUG" if args_parsed.debug else args_parsed.log_level,
+        auth_bearer_token=auth_bearer_token or None,
     )
 
 

--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -1,6 +1,7 @@
 """Create a local SSE server that proxies requests to a stdio MCP server."""
 
 import contextlib
+import hmac
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
@@ -15,17 +16,21 @@ from mcp.server.sse import SseServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import BaseRoute, Mount, Route
-from starlette.types import Receive, Scope, Send
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .proxy_server import create_proxy_server
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_EXPOSE_HEADERS: Final[tuple[str, ...]] = ("mcp-session-id",)
+
+# Path prefixes that bypass Bearer auth (health checks, no sensitive data).
+_AUTH_BYPASS_PATH_PREFIXES: Final[tuple[str, ...]] = ("/status",)
 
 
 def _default_expose_headers() -> list[str]:
@@ -42,6 +47,48 @@ class MCPServerSettings:
     allow_origins: list[str] | None = None
     expose_headers: list[str] = field(default_factory=_default_expose_headers)
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    auth_bearer_token: str | None = None
+
+
+class BearerAuthMiddleware(BaseHTTPMiddleware):
+    """Require an `Authorization: Bearer <token>` header on protected routes.
+
+    The token is compared in constant time. Requests that target a path under
+    `_AUTH_BYPASS_PATH_PREFIXES` (e.g. `/status`) are forwarded without
+    authentication. Missing or invalid credentials yield a 401 with a
+    `WWW-Authenticate: Bearer` challenge.
+    """
+
+    def __init__(self, app: ASGIApp, *, token: str) -> None:
+        """Initialize the middleware. ``token`` must be a non-empty string."""
+        super().__init__(app)
+        if not token:
+            msg = "BearerAuthMiddleware requires a non-empty token"
+            raise ValueError(msg)
+        self._token = token
+
+    async def dispatch(  # type: ignore[override]
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        """Validate the bearer token, then forward the request or reject with 401."""
+        path = request.url.path
+        if any(path.startswith(prefix) for prefix in _AUTH_BYPASS_PATH_PREFIXES):
+            return await call_next(request)
+
+        header = request.headers.get("authorization", "")
+        scheme, _, credentials = header.partition(" ")
+        if scheme.lower() != "bearer" or not credentials or not hmac.compare_digest(
+            credentials,
+            self._token,
+        ):
+            return JSONResponse(
+                {"error": "unauthorized", "error_description": "Bearer token required"},
+                status_code=401,
+                headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+            )
+        return await call_next(request)
 
 
 # To store last activity for multiple servers if needed, though status endpoint is global for now.
@@ -145,6 +192,30 @@ def create_single_instance_routes(
     return routes, http_session_manager
 
 
+def _build_middleware_stack(mcp_settings: MCPServerSettings) -> list[Middleware]:
+    """Assemble the Starlette middleware list for the proxied MCP application."""
+    middleware: list[Middleware] = []
+    if mcp_settings.allow_origins:
+        middleware.append(
+            Middleware(
+                CORSMiddleware,
+                allow_origins=mcp_settings.allow_origins,
+                allow_methods=["*"],
+                allow_headers=["*"],
+                expose_headers=mcp_settings.expose_headers,
+            ),
+        )
+    if mcp_settings.auth_bearer_token:
+        middleware.append(
+            Middleware(
+                BearerAuthMiddleware,
+                token=mcp_settings.auth_bearer_token,
+            ),
+        )
+        logger.info("Bearer token authentication enabled.")
+    return middleware
+
+
 async def run_mcp_server(
     mcp_settings: MCPServerSettings,
     default_server_params: StdioServerParameters | None = None,
@@ -215,17 +286,7 @@ async def run_mcp_server(
             logger.error("No servers configured to run.")
             return
 
-        middleware: list[Middleware] = []
-        if mcp_settings.allow_origins:
-            middleware.append(
-                Middleware(
-                    CORSMiddleware,
-                    allow_origins=mcp_settings.allow_origins,
-                    allow_methods=["*"],
-                    allow_headers=["*"],
-                    expose_headers=mcp_settings.expose_headers,
-                ),
-            )
+        middleware = _build_middleware_stack(mcp_settings)
 
         starlette_app = Starlette(
             debug=(mcp_settings.log_level == "DEBUG"),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -738,3 +738,73 @@ async def test_run_mcp_server_both_default_and_named_servers(
         )
 
         mock_server_instance.serve.assert_called_once()
+
+
+# --- Bearer auth middleware tests -------------------------------------------
+
+
+from starlette.requests import Request  # noqa: E402
+from starlette.responses import PlainTextResponse  # noqa: E402
+from starlette.routing import Route as _Route  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from mcp_proxy.mcp_server import BearerAuthMiddleware  # noqa: E402
+
+
+def _build_app_with_bearer(token: str) -> Starlette:
+    """Build a minimal Starlette app guarded by ``BearerAuthMiddleware``."""
+
+    async def secret(_: Request) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    async def status(_: Request) -> PlainTextResponse:
+        return PlainTextResponse("status-ok")
+
+    return Starlette(
+        routes=[_Route("/secret", endpoint=secret), _Route("/status", endpoint=status)],
+        middleware=[Middleware(BearerAuthMiddleware, token=token)],
+    )
+
+
+def test_bearer_auth_rejects_missing_header() -> None:
+    """Requests without an Authorization header are rejected with 401."""
+    client = TestClient(_build_app_with_bearer("s3cret"))
+    response = client.get("/secret")
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"].lower().startswith("bearer")
+
+
+def test_bearer_auth_rejects_wrong_scheme() -> None:
+    """A non-Bearer scheme (e.g. Basic) is rejected with 401."""
+    client = TestClient(_build_app_with_bearer("s3cret"))
+    response = client.get("/secret", headers={"Authorization": "Basic s3cret"})
+    assert response.status_code == 401
+
+
+def test_bearer_auth_rejects_wrong_token() -> None:
+    """A Bearer token that does not match the configured value yields 401."""
+    client = TestClient(_build_app_with_bearer("s3cret"))
+    response = client.get("/secret", headers={"Authorization": "Bearer nope"})
+    assert response.status_code == 401
+
+
+def test_bearer_auth_accepts_valid_token() -> None:
+    """A request carrying the correct Bearer token reaches the endpoint."""
+    client = TestClient(_build_app_with_bearer("s3cret"))
+    response = client.get("/secret", headers={"Authorization": "Bearer s3cret"})
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+def test_bearer_auth_bypasses_status() -> None:
+    """The /status health endpoint is reachable without authentication."""
+    client = TestClient(_build_app_with_bearer("s3cret"))
+    response = client.get("/status")
+    assert response.status_code == 200
+    assert response.text == "status-ok"
+
+
+def test_bearer_auth_rejects_empty_token_init() -> None:
+    """Constructing ``BearerAuthMiddleware`` with an empty token raises ValueError."""
+    with pytest.raises(ValueError, match="non-empty token"):
+        BearerAuthMiddleware(app=lambda *_: None, token="")


### PR DESCRIPTION
## Summary

Adds an opt-in `--auth-bearer-token` flag (with `MCP_PROXY_AUTH_TOKEN` env-var fallback) that requires `Authorization: Bearer <token>` on every route **except** `/status`.

When neither the flag nor the env var is set, **no middleware is attached** and behavior is identical to today — this change is fully backward-compatible.

## Motivation

Running `mcp-proxy` as a single front-door for multiple MCP servers (in my case `searxng`, `sk-agent`, and a private `roo-state-manager`) behind a shared secret, without needing to front it with nginx/Traefik just for auth. A lot of self-hosted deployments want basic bearer auth with zero additional moving parts.

## Design

- **`BearerAuthMiddleware`** — a small `Starlette BaseHTTPMiddleware` subclass
  - Constant-time comparison via `hmac.compare_digest` (defense against timing attacks)
  - `/status` is bypassed via a `_AUTH_BYPASS_PATH_PREFIXES` tuple so health-check probes keep working
  - Missing/invalid credentials → `401` with `WWW-Authenticate: Bearer realm=\"mcp-proxy\"` (RFC 6750)
  - Case-insensitive scheme matching (`Bearer` / `bearer`)
  - Rejects empty token at construction time (fail-fast)

- **`MCPServerSettings`** extended with `auth_bearer_token: str | None = None`

- **CLI / env-var** — `__main__.py`:
  ```
  --auth-bearer-token TOKEN    (optional, defaults to MCP_PROXY_AUTH_TOKEN)
  ```
  Env-var fallback is preferred for production (no token in `ps`/process args).

- **Complexity** — extracted `_build_middleware_stack()` helper to keep `run_mcp_server` under the project's `C901` limit.

## Security notes

- Constant-time comparison (`hmac.compare_digest`)
- No token leakage in logs (only an INFO line \"Bearer token authentication enabled.\")
- Recommended deployment: set `MCP_PROXY_AUTH_TOKEN` via env, not CLI
- `/status` is the only bypassed path and returns no sensitive data

## Tests

6 new unit tests in `tests/test_mcp_server.py`:
- rejects missing header → 401 + WWW-Authenticate
- rejects wrong scheme → 401
- rejects wrong token → 401
- accepts valid token → 200
- bypasses `/status` without auth → 200
- rejects empty token at middleware construction → ValueError

Full suite: **84 passed** (78 pre-existing + 6 new), lint baseline unchanged.

End-to-end tested against a real MCP Streamable-HTTP session (initialize + notifications/initialized + tools/call + 5 parallel tools/call) — the proxy's concurrency behavior is preserved when auth is enabled.

## Usage

```bash
# CLI
mcp-proxy --auth-bearer-token s3cr3t --port 9000 \
  --named-server mymcp /path/to/mcp

# Env var (recommended for production)
export MCP_PROXY_AUTH_TOKEN=s3cr3t
mcp-proxy --port 9000 --named-server mymcp /path/to/mcp
```

Client:
```
Authorization: Bearer s3cr3t
```

Happy to iterate on naming, docstrings, or split the PR if you'd prefer.