### PR TITLE
feat: forward roots/list requests through the proxy to the upstream c…

### DIFF
--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -13,14 +13,68 @@ from mcp.server.lowlevel.server import request_ctx
 logger = logging.getLogger(__name__)
 
 
-async def create_proxy_server(remote_app: ClientSession) -> server.Server[object]:  # noqa: C901, PLR0915
-    """Create a server instance from a remote app."""
+def create_roots_forwarding_callback(
+    proxy_app: server.Server[object],
+) -> t.Callable[..., t.Awaitable[types.ListRootsResult | types.ErrorData]]:
+    """Create a list_roots callback that forwards roots/list requests to the upstream client.
+
+    When a downstream server sends a roots/list request, this callback forwards it
+    through the proxy's upstream session to the connected client.
+
+    The proxy_app's request_context is only available during active request handling
+    (tool calls, resource reads, etc.), which is when downstream servers typically
+    request roots. If a roots/list request arrives outside of an active request
+    context, an INVALID_REQUEST error is returned.
+    """
+
+    async def _forward_roots(_ctx: t.Any) -> types.ListRootsResult | types.ErrorData:  # noqa: ANN401
+        try:
+            result = await proxy_app.request_context.session.list_roots()
+            return result
+        except LookupError:
+            # request_context not set — no active upstream session
+            logger.warning("roots/list requested but no active upstream session available")
+            return types.ErrorData(
+                code=types.INVALID_REQUEST,
+                message="No active upstream session to forward roots/list request",
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Failed to forward roots/list to upstream client: %s", e)
+            return types.ErrorData(
+                code=types.INTERNAL_ERROR,
+                message=f"Failed to forward roots/list: {e}",
+            )
+
+    return _forward_roots
+
+
+async def create_proxy_server(
+    remote_app: ClientSession,
+) -> server.Server[object]:  # noqa: C901, PLR0915
+    """Create a server instance from a remote app.
+
+    Roots/list requests from the downstream server are forwarded through the proxy
+    server's upstream session to the connected client. The callback is injected into
+    remote_app before initialize() so that the downstream server sees roots capability
+    advertised during the handshake.
+    """
+    # Create the proxy server first — needed to build the roots forwarding callback
+    # before we advertise capabilities to the downstream server via initialize().
+    app: server.Server[object] = server.Server(name="mcp-proxy")
+
+    # Wire roots forwarding: downstream server → proxy → upstream client.
+    # Must happen before initialize() so the ClientSession advertises roots
+    # capability to the downstream server during the handshake.
+    callback = create_roots_forwarding_callback(app)
+    remote_app._list_roots_callback = callback  # noqa: SLF001
+
     logger.debug("Sending initialization request to remote MCP server...")
     response = await remote_app.initialize()
     capabilities = response.capabilities
 
+    # Update the server name now that we know it from the downstream server
+    app.name = response.serverInfo.name
     logger.debug("Configuring proxied MCP server...")
-    app: server.Server[object] = server.Server(name=response.serverInfo.name)
 
     if capabilities.prompts:
         logger.debug("Capabilities: adding Prompts...")
@@ -159,3 +213,4 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
     app.request_handlers[types.CompleteRequest] = _complete
 
     return app
+

--- a/tests/test_roots_forwarding.py
+++ b/tests/test_roots_forwarding.py
@@ -1,0 +1,169 @@
+"""Tests for roots/list forwarding through the proxy.
+
+Verifies that:
+- The proxy advertises roots capability to downstream servers.
+- roots/list requests are forwarded from downstream → proxy → upstream client.
+- The callback gracefully handles missing request context and upstream errors.
+"""
+
+import typing as t
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+import pytest
+from mcp import server, types
+from mcp.server import Server
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcp_proxy.proxy_server import create_proxy_server, create_roots_forwarding_callback
+
+in_memory = create_connected_server_and_client_session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_server() -> Server[object]:
+    """Provide a minimal server with a tool (needed to trigger request_context)."""
+    srv = Server("test-server")
+
+    @srv.list_tools()  # type: ignore[no-untyped-call,misc]
+    async def _() -> list[types.Tool]:  # pragma: no cover — only needed to advertise capability
+        return [
+            types.Tool(
+                name="echo",
+                description="Echo tool",
+                inputSchema={"type": "object", "properties": {"msg": {"type": "string"}}},
+            )
+        ]
+
+    @srv.call_tool()  # type: ignore[misc]
+    async def _call(_name: str, arguments: dict[str, t.Any] | None) -> list[types.Content]:  # pragma: no cover
+        return [types.TextContent(type="text", text=str(arguments))]
+
+    return srv
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: roots through the proxy
+# ---------------------------------------------------------------------------
+
+
+async def test_proxy_advertises_roots_capability(test_server: Server[object]) -> None:
+    """The proxy should advertise roots capability to the downstream server."""
+    async with in_memory(test_server) as session:
+        wrapped = await create_proxy_server(session)
+        # The outer client connects with a roots callback
+        async with in_memory(
+            wrapped,
+            list_roots_callback=AsyncMock(return_value=types.ListRootsResult(roots=[])),
+        ) as outer_session:
+            await outer_session.initialize()
+            # The downstream server should see that the *client* (which is the proxy's
+            # ClientSession connected to it) advertises roots capability.
+            # We verify this by checking that the inner session (which talks to the
+            # real server) had its callback replaced.
+            assert session._list_roots_callback is not None  # noqa: SLF001
+
+
+async def test_proxy_callback_is_set_before_initialize(test_server: Server[object]) -> None:
+    """The roots callback must be injected before initialize() to advertise the capability."""
+    async with in_memory(test_server) as session:
+        # Before create_proxy_server, the callback is the default (error-returning)
+        from mcp.client.session import _default_list_roots_callback
+
+        original_callback = session._list_roots_callback  # noqa: SLF001
+        assert original_callback is _default_list_roots_callback
+
+        # After create_proxy_server, it should be our forwarding callback
+        await create_proxy_server(session)
+        assert session._list_roots_callback is not original_callback  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: create_roots_forwarding_callback edge cases
+# ---------------------------------------------------------------------------
+
+
+async def test_callback_returns_error_when_no_request_context() -> None:
+    """When request_context is not set (no active upstream session), return ErrorData."""
+    app: server.Server[object] = server.Server(name="test-proxy")
+
+    callback = create_roots_forwarding_callback(app)
+    result = await callback(None)  # ctx is unused
+
+    assert isinstance(result, types.ErrorData)
+    assert result.code == types.INVALID_REQUEST
+    assert "No active upstream session" in result.message
+
+
+async def test_callback_returns_error_on_upstream_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the upstream session raises, return ErrorData with INTERNAL_ERROR."""
+    app: server.Server[object] = server.Server(name="test-proxy")
+
+    # Mock request_context to have a session that raises on list_roots
+    mock_session = MagicMock()
+    mock_session.list_roots = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+    mock_context = MagicMock()
+    mock_context.session = mock_session
+
+    # Patch request_context on the class (auto-restored by monkeypatch)
+    monkeypatch.setattr(type(app), "request_context", PropertyMock(return_value=mock_context))
+
+    callback = create_roots_forwarding_callback(app)
+    result = await callback(None)
+
+    assert isinstance(result, types.ErrorData)
+    assert result.code == types.INTERNAL_ERROR
+    assert "connection lost" in result.message
+
+
+async def test_callback_forwards_roots_successfully(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When upstream session returns roots, forward them unchanged."""
+    app: server.Server[object] = server.Server(name="test-proxy")
+
+    expected_roots = types.ListRootsResult(
+        roots=[
+            types.Root(uri="file:///project", name="project"),
+        ]
+    )
+
+    mock_session = MagicMock()
+    mock_session.list_roots = AsyncMock(return_value=expected_roots)
+
+    mock_context = MagicMock()
+    mock_context.session = mock_session
+
+    monkeypatch.setattr(type(app), "request_context", PropertyMock(return_value=mock_context))
+
+    callback = create_roots_forwarding_callback(app)
+    result = await callback(None)
+
+    assert isinstance(result, types.ListRootsResult)
+    assert len(result.roots) == 1
+    assert result.roots[0].name == "project"
+    assert str(result.roots[0].uri) == "file:///project"
+
+
+async def test_callback_forwards_empty_roots(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When upstream client has no roots, forward the empty list."""
+    app: server.Server[object] = server.Server(name="test-proxy")
+
+    expected_roots = types.ListRootsResult(roots=[])
+
+    mock_session = MagicMock()
+    mock_session.list_roots = AsyncMock(return_value=expected_roots)
+
+    mock_context = MagicMock()
+    mock_context.session = mock_session
+
+    monkeypatch.setattr(type(app), "request_context", PropertyMock(return_value=mock_context))
+
+    callback = create_roots_forwarding_callback(app)
+    result = await callback(None)
+
+    assert isinstance(result, types.ListRootsResult)
+    assert result.roots == []


### PR DESCRIPTION
# Forward roots/list requests through the proxy to the upstream client

## Problem

The proxy server does not forward `roots/list` requests from downstream servers to the upstream client. The MCP SDK's `ClientSession` defaults `_list_roots_callback` to a function that returns `ErrorData("List roots not supported")`. Since the proxy never overrides this callback, downstream servers (which request roots to discover workspace boundaries) always receive an error — even when the upstream client fully supports roots.

This breaks any downstream server that relies on roots for path validation, security boundaries, or workspace-scoped operations.

## Solution

**New function: `create_roots_forwarding_callback(proxy_app)`**

Creates a callback that intercepts `roots/list` requests and forwards them through `proxy_app.request_context.session.list_roots()` to the upstream client. The `request_context` is a `ContextVar` that is set during active request handling (tool calls, resource reads, etc.) — which is exactly when downstream servers request roots.

**Restructured `create_proxy_server()` initialization order:**

1. Create `server.Server` instance first (previously created after `initialize()`)
2. Build the forwarding callback from the server instance
3. Inject callback into `remote_app._list_roots_callback` **before** calling `initialize()` — this ensures the `ClientSession` advertises `roots` capability during the handshake
4. Set `app.name` from `response.serverInfo.name` after initialization (previously set in the constructor)

**Error handling:**

| Scenario | Behavior |
|---|---|
| No active request context (`LookupError`) | Returns `ErrorData(INVALID_REQUEST)` with descriptive message |
| Upstream client error/disconnect | Returns `ErrorData(INTERNAL_ERROR)` with error details |
| Upstream returns roots | Forwards `ListRootsResult` unchanged |

## Tests

Added `tests/test_roots_forwarding.py` with 6 tests:

- **Integration:** proxy advertises roots capability; callback is injected before `initialize()`
- **Unit:** no request context → `ErrorData`; upstream exception → `ErrorData`; successful forwarding; empty roots list

All 46 tests pass (40 existing + 6 new).

## Notes

- This patch accesses `remote_app._list_roots_callback` (a private attribute) because there is no public API to set the callback post-construction. The `ClientSession` constructor accepts `list_roots_callback`, but the proxy creates the server instance first and needs to wire the callback before initialization — after the `ClientSession` is already constructed.
- No changes to the public API surface. Fully backward compatible.
