### PR TITLE
fix: expand environment variables in server config values

### DIFF
--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -349,7 +349,9 @@ def _configure_default_server(
         return None
 
     default_server_env = base_env.copy()
-    default_server_env.update(dict(args_parsed.env))  # Specific env vars for default server
+    default_server_env.update(
+        {k: os.path.expandvars(os.path.expanduser(v)) for k, v in args_parsed.env}
+    )
 
     default_stdio_params = StdioServerParameters(
         command=args_parsed.command_or_url,

--- a/src/mcp_proxy/config_loader.py
+++ b/src/mcp_proxy/config_loader.py
@@ -5,6 +5,7 @@ This module provides functionality to load named server configurations from JSON
 
 import json
 import logging
+import os
 from pathlib import Path
 
 from mcp.client.stdio import StdioServerParameters
@@ -85,7 +86,9 @@ def load_named_server_configs_from_file(
             continue
 
         new_env = base_env.copy()
-        new_env.update(env)
+        new_env.update(
+            {k: os.path.expandvars(os.path.expanduser(v)) for k, v in env.items()}
+        )
 
         named_stdio_params[name] = StdioServerParameters(
             command=command,

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -247,3 +247,66 @@ def test_config_file_is_empty_string() -> None:
         path = Path(tmp_config_path)
         if path.exists():
             path.unlink()
+
+
+def test_env_var_expansion_in_config(
+    create_temp_config_file: Callable[[dict[str, t.Any]], str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that environment variables in config values are expanded."""
+    monkeypatch.setenv("MY_TEST_VAR", "/expanded/path")
+    config_content = {
+        "mcpServers": {
+            "server1": {
+                "command": "echo",
+                "env": {"DATA_DIR": "$MY_TEST_VAR/data", "STATIC": "no_expansion"},
+            },
+        },
+    }
+    tmp_config_path = create_temp_config_file(config_content)
+    loaded_params = load_named_server_configs_from_file(tmp_config_path, {})
+
+    assert loaded_params["server1"].env is not None
+    assert loaded_params["server1"].env["DATA_DIR"] == "/expanded/path/data"
+    assert loaded_params["server1"].env["STATIC"] == "no_expansion"
+
+
+def test_env_var_expansion_with_braces(
+    create_temp_config_file: Callable[[dict[str, t.Any]], str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that ${VAR} syntax is expanded in env values."""
+    monkeypatch.setenv("HOME", "/home/testuser")
+    config_content = {
+        "mcpServers": {
+            "server1": {
+                "command": "echo",
+                "env": {"DB_PATH": "${HOME}/.local/share/db.sqlite"},
+            },
+        },
+    }
+    tmp_config_path = create_temp_config_file(config_content)
+    loaded_params = load_named_server_configs_from_file(tmp_config_path, {})
+
+    assert loaded_params["server1"].env is not None
+    assert loaded_params["server1"].env["DB_PATH"] == "/home/testuser/.local/share/db.sqlite"
+
+
+def test_tilde_expansion_in_env(
+    create_temp_config_file: Callable[[dict[str, t.Any]], str],
+) -> None:
+    """Test that ~ is expanded in env values."""
+    config_content = {
+        "mcpServers": {
+            "server1": {
+                "command": "echo",
+                "env": {"CONFIG": "~/my-config"},
+            },
+        },
+    }
+    tmp_config_path = create_temp_config_file(config_content)
+    loaded_params = load_named_server_configs_from_file(tmp_config_path, {})
+
+    assert loaded_params["server1"].env is not None
+    assert loaded_params["server1"].env["CONFIG"].startswith("/")
+    assert "~" not in loaded_params["server1"].env["CONFIG"]


### PR DESCRIPTION
## Summary

Expand `$HOME`, `$VAR`, `${VAR}` and `~` in env values from both config files (`--named-server-config`) and CLI `-e` arguments.

## Problem

Environment variable references like `${HOME}` in server config env values are passed as literal strings to child processes. This causes server startup failures when paths depend on env var expansion (e.g., `${HOME}/.local/share/db.sqlite` is passed literally instead of `/home/user/.local/share/db.sqlite`).

This is a common issue when running mcp-proxy with multiple servers across different machines where home directories differ.

## Changes

- **`config_loader.py`**: Apply `os.path.expandvars()` + `os.path.expanduser()` to env values loaded from config files
- **`__main__.py`**: Apply the same expansion to env values passed via `-e` CLI arguments
- **Tests**: 3 new tests covering `$VAR`, `${VAR}`, and `~` expansion

## Testing

- All 81 tests pass (78 existing + 3 new)
- mypy strict: no issues
- Tested manually with a config using `${HOME}` in env values

Fixes #120