### PR TITLE
fix: graceful handling of named server startup failures

### DIFF
--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -187,32 +187,55 @@ async def run_mcp_server(
             _global_status["server_instances"]["default"] = "configured"
 
         # Setup named servers
+        failed_servers: list[str] = []
         for name, params in named_server_params.items():
-            logger.info(
-                "Setting up named server '%s': %s %s",
-                name,
-                params.command,
-                " ".join(params.args),
-            )
-            stdio_streams_named = await stack.enter_async_context(stdio_client(params))
-            session_named = await stack.enter_async_context(ClientSession(*stdio_streams_named))
-            proxy_named = await create_proxy_server(session_named)
+            try:
+                logger.info(
+                    "Setting up named server '%s': %s %s",
+                    name,
+                    params.command,
+                    " ".join(params.args),
+                )
+                stdio_streams_named = await stack.enter_async_context(stdio_client(params))
+                session_named = await stack.enter_async_context(ClientSession(*stdio_streams_named))
+                proxy_named = await create_proxy_server(session_named)
 
-            instance_routes_named, http_manager_named = create_single_instance_routes(
-                proxy_named,
-                stateless_instance=mcp_settings.stateless,
-            )
-            await stack.enter_async_context(
-                http_manager_named.run(),
-            )  # Manage lifespan by calling run()
+                instance_routes_named, http_manager_named = create_single_instance_routes(
+                    proxy_named,
+                    stateless_instance=mcp_settings.stateless,
+                )
+                await stack.enter_async_context(
+                    http_manager_named.run(),
+                )  # Manage lifespan by calling run()
 
-            # Mount these routes under /servers/<name>/
-            server_mount = Mount(f"/servers/{name}", routes=instance_routes_named)
-            all_routes.append(server_mount)
-            _global_status["server_instances"][name] = "configured"
+                # Mount these routes under /servers/<name>/
+                server_mount = Mount(f"/servers/{name}", routes=instance_routes_named)
+                all_routes.append(server_mount)
+                _global_status["server_instances"][name] = "configured"
+            except Exception:
+                logger.exception(
+                    "Failed to start named server '%s'. Skipping this server.",
+                    name,
+                )
+                _global_status["server_instances"][name] = "failed"
+                failed_servers.append(name)
+
+        if failed_servers:
+            logger.warning(
+                "The following named servers failed to start and were skipped: %s",
+                ", ".join(failed_servers),
+            )
 
         if not default_server_params and not named_server_params:
             logger.error("No servers configured to run.")
+            return
+
+        # Check if all named servers failed and there's no default server
+        has_running_named = len(named_server_params) > len(failed_servers)
+        if not default_server_params and not has_running_named:
+            logger.error(
+                "No servers are running. All named servers failed to start.",
+            )
             return
 
         middleware: list[Middleware] = []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -738,3 +738,84 @@ async def test_run_mcp_server_both_default_and_named_servers(
         )
 
         mock_server_instance.serve.assert_called_once()
+
+
+async def test_run_mcp_server_named_server_failure_does_not_crash_others(
+    mock_settings: MCPServerSettings,
+    mock_stdio_params: StdioServerParameters,
+) -> None:
+    """Test that a failing named server does not prevent other servers from starting."""
+    named_servers = {
+        "good_server": mock_stdio_params,
+        "bad_server": StdioServerParameters(
+            command="nonexistent_command",
+            args=[],
+            env={},
+            cwd=None,
+        ),
+    }
+
+    call_count = 0
+
+    def stdio_client_side_effect(params: StdioServerParameters) -> t.Any:
+        nonlocal call_count
+        call_count += 1
+        if params.command == "nonexistent_command":
+            raise FileNotFoundError("Command not found: nonexistent_command")
+        mock_stdio_context, _, _, _, _ = setup_async_context_mocks()
+        return mock_stdio_context
+
+    with (
+        patch("mcp_proxy.mcp_server.stdio_client", side_effect=stdio_client_side_effect),
+        patch("mcp_proxy.mcp_server.ClientSession") as mock_client_session,
+        patch("mcp_proxy.mcp_server.create_proxy_server") as mock_create_proxy,
+        patch("mcp_proxy.mcp_server.create_single_instance_routes") as mock_create_routes,
+        patch("uvicorn.Server") as mock_uvicorn_server,
+        patch("mcp_proxy.mcp_server.logger") as mock_logger,
+    ):
+        _, mock_session_context, _, mock_http_manager, mock_routes = setup_async_context_mocks()
+        mock_client_session.return_value = mock_session_context
+
+        mock_proxy = AsyncMock()
+        mock_create_proxy.return_value = mock_proxy
+        mock_create_routes.return_value = (mock_routes, mock_http_manager)
+
+        mock_server_instance = AsyncMock()
+        mock_uvicorn_server.return_value = mock_server_instance
+
+        await run_mcp_server(mock_settings, None, named_servers)
+
+        # The good server should have been set up successfully
+        assert mock_create_proxy.call_count == 1
+
+        # The bad server should have been logged as failed
+        mock_logger.exception.assert_called_with(
+            "Failed to start named server '%s'. Skipping this server.",
+            "bad_server",
+        )
+
+        # Server should still be running (serve was called)
+        mock_server_instance.serve.assert_called_once()
+
+
+async def test_run_mcp_server_all_named_servers_fail_no_default(
+    mock_settings: MCPServerSettings,
+) -> None:
+    """Test that proxy exits gracefully when all named servers fail and no default is set."""
+    named_servers = {
+        "bad1": StdioServerParameters(command="bad1", args=[], env={}, cwd=None),
+        "bad2": StdioServerParameters(command="bad2", args=[], env={}, cwd=None),
+    }
+
+    with (
+        patch(
+            "mcp_proxy.mcp_server.stdio_client",
+            side_effect=FileNotFoundError("not found"),
+        ),
+        patch("mcp_proxy.mcp_server.logger") as mock_logger,
+    ):
+        await run_mcp_server(mock_settings, None, named_servers)
+
+        mock_logger.error.assert_called_with(
+            "No servers are running. All named servers failed to start.",
+        )


### PR DESCRIPTION
## Summary

Wrap each named server initialization in try/except so that a single server failing to start does not crash the entire proxy.

## Problem

When running mcp-proxy with multiple named servers (e.g., 8+ servers via `--named-server-config`), if **any** server fails to start (missing dependency, wrong command, network issue), the entire proxy crashes and **all** servers become unavailable.

This is a critical issue for production setups where some servers may depend on external resources (VPN, databases) that aren't always available.

### Real-world scenario

```json
{
  "mcpServers": {
    "memory-service": { "command": "uvx", "args": ["mcp-memory-service"] },
    "task-orchestrator": { "command": "uvx", "args": ["task-orchestrator"] },
    "db-mcp": { "command": "./db-wrapper.sh" },
    "elm-alm": { "command": "python", "args": ["-m", "elm_mcp"] }
  }
}
```

If `db-mcp` fails (e.g., no VPN), memory-service and task-orchestrator also go down — even though they have no dependency on db-mcp.

## Changes

- **`mcp_server.py`**: Wrap each named server setup in try/except. Failed servers are logged and marked as `failed` in the `/status` endpoint. Other servers continue normally.
- If all named servers fail and no default server exists, the proxy exits gracefully with a clear error message.
- **Tests**: 2 new tests covering partial failure and total failure scenarios.

## Testing

- All 80 tests pass (78 existing + 2 new)
- mypy strict: no issues

Relates to #75