### PR TITLE
feat: add API key authentication for proxy endpoints

### DIFF
--- a/src/mcp_proxy/__main__.py
+++ b/src/mcp_proxy/__main__.py
@@ -273,6 +273,17 @@ def _add_arguments_to_parser(parser: argparse.ArgumentParser) -> None:
             "Defaults to 'Mcp-Session-Id'. Can be used multiple times."
         ),
     )
+    mcp_server_group.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        metavar="KEY",
+        help=(
+            "API key to require for all requests (except /health, /status, and CORS preflight). "
+            "Clients must send 'Authorization: Bearer <KEY>'. "
+            "Can also be set via MCP_PROXY_API_KEY environment variable."
+        ),
+    )
 
 
 def _setup_logging(*, level: str, debug: bool) -> logging.Logger:
@@ -436,6 +447,7 @@ def _create_mcp_settings(args_parsed: argparse.Namespace) -> MCPServerSettings:
         if not args_parsed.expose_headers
         else list(args_parsed.expose_headers)
     )
+    api_key = args_parsed.api_key or os.getenv("MCP_PROXY_API_KEY")
     return MCPServerSettings(
         bind_host=args_parsed.host if args_parsed.host is not None else args_parsed.sse_host,
         port=args_parsed.port if args_parsed.port is not None else args_parsed.sse_port,
@@ -443,6 +455,7 @@ def _create_mcp_settings(args_parsed: argparse.Namespace) -> MCPServerSettings:
         allow_origins=args_parsed.allow_origin if len(args_parsed.allow_origin) > 0 else None,
         expose_headers=expose_headers,
         log_level="DEBUG" if args_parsed.debug else args_parsed.log_level,
+        api_key=api_key,
     )
 
 

--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -25,6 +25,50 @@ from .proxy_server import create_proxy_server
 
 logger = logging.getLogger(__name__)
 
+# Paths that bypass API key authentication
+_PUBLIC_PATHS: Final[frozenset[str]] = frozenset({"/health", "/status"})
+
+
+class APIKeyMiddleware:
+    """Starlette middleware that validates Bearer token authentication.
+
+    Skips validation for health/status endpoints and CORS preflight requests.
+    When no api_key is configured, all requests pass through (backward compatible).
+    """
+
+    def __init__(self, app: Any, *, api_key: str) -> None:
+        self._app = app
+        self._api_key = api_key
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        method = scope.get("method", "")
+
+        # Skip auth for public paths and CORS preflight
+        if path in _PUBLIC_PATHS or method == "OPTIONS":
+            await self._app(scope, receive, send)
+            return
+
+        # Extract Authorization header
+        headers = dict(scope.get("headers", []))
+        auth_value = headers.get(b"authorization", b"").decode()
+
+        if auth_value == f"Bearer {self._api_key}":
+            await self._app(scope, receive, send)
+            return
+
+        # Reject
+        response = JSONResponse(
+            {"error": "Unauthorized", "message": "Invalid or missing API key"},
+            status_code=401,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+        await response(scope, receive, send)
+
 DEFAULT_EXPOSE_HEADERS: Final[tuple[str, ...]] = ("mcp-session-id",)
 
 
@@ -42,6 +86,7 @@ class MCPServerSettings:
     allow_origins: list[str] | None = None
     expose_headers: list[str] = field(default_factory=_default_expose_headers)
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    api_key: str | None = None
 
 
 # To store last activity for multiple servers if needed, though status endpoint is global for now.
@@ -226,6 +271,12 @@ async def run_mcp_server(
                     expose_headers=mcp_settings.expose_headers,
                 ),
             )
+
+        if mcp_settings.api_key:
+            middleware.append(
+                Middleware(APIKeyMiddleware, api_key=mcp_settings.api_key),
+            )
+            logger.info("API key authentication enabled")
 
         starlette_app = Starlette(
             debug=(mcp_settings.log_level == "DEBUG"),

--- a/tests/test_api_key_auth.py
+++ b/tests/test_api_key_auth.py
@@ -1,0 +1,211 @@
+"""Tests for API key authentication middleware."""
+# ruff: noqa: PLR2004, S101
+
+import asyncio
+import contextlib
+import typing as t
+
+import httpx
+import pytest
+import uvicorn
+from mcp import types
+from mcp.server import Server
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from mcp_proxy.mcp_server import APIKeyMiddleware, MCPServerSettings, create_single_instance_routes
+
+API_KEY = "test-secret-key"
+
+
+def _create_test_app(*, api_key: str | None = API_KEY) -> Starlette:
+    """Create a minimal Starlette app with auth middleware for testing."""
+    mcp_server: Server[object, t.Any] = Server("TestServer")
+
+    @mcp_server.list_tools()  # type: ignore[misc,no-untyped-call]
+    async def list_tools() -> list[types.Tool]:
+        return []
+
+    routes, http_manager = create_single_instance_routes(mcp_server, stateless_instance=False)
+
+    # Add health/status routes like the real server
+    async def handle_health(_: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok"})
+
+    routes = [
+        Route("/health", endpoint=handle_health),
+        Route("/status", endpoint=handle_health),
+        *routes,
+    ]
+
+    middleware: list[Middleware] = []
+    if api_key:
+        middleware.append(Middleware(APIKeyMiddleware, api_key=api_key))
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_app: Starlette) -> t.AsyncIterator[None]:
+        async with http_manager.run():
+            yield
+
+    app = Starlette(routes=routes, middleware=middleware, lifespan=lifespan)
+    app.router.redirect_slashes = False
+    return app
+
+
+class _BackgroundServer(uvicorn.Server):
+    def install_signal_handlers(self) -> None:
+        pass
+
+    @contextlib.asynccontextmanager
+    async def run_in_background(self) -> t.AsyncIterator[None]:
+        task = asyncio.create_task(self.serve())
+        try:
+            while not self.started:
+                await asyncio.sleep(1e-3)
+            yield
+        finally:
+            self.should_exit = self.force_exit = True
+            await task
+
+    @property
+    def url(self) -> str:
+        hostport = next(
+            iter([s.getsockname() for srv in self.servers for s in srv.sockets]),
+        )
+        return f"http://{hostport[0]}:{hostport[1]}"
+
+
+@pytest.fixture
+async def auth_server() -> t.AsyncIterator[str]:
+    """Start a test server with API key auth enabled."""
+    app = _create_test_app(api_key=API_KEY)
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="warning")
+    server = _BackgroundServer(config)
+    async with server.run_in_background():
+        yield server.url
+
+
+@pytest.fixture
+async def noauth_server() -> t.AsyncIterator[str]:
+    """Start a test server without API key auth."""
+    app = _create_test_app(api_key=None)
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="warning")
+    server = _BackgroundServer(config)
+    async with server.run_in_background():
+        yield server.url
+
+
+async def test_health_bypasses_auth(auth_server: str) -> None:
+    """Health endpoint should be accessible without auth."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{auth_server}/health")
+        assert resp.status_code == 200
+
+
+async def test_status_bypasses_auth(auth_server: str) -> None:
+    """Status endpoint should be accessible without auth."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{auth_server}/status")
+        assert resp.status_code == 200
+
+
+async def test_sse_rejected_without_auth(auth_server: str) -> None:
+    """SSE endpoint should reject requests without auth header."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{auth_server}/sse")
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "Unauthorized"
+
+
+async def test_sse_rejected_with_wrong_key(auth_server: str) -> None:
+    """SSE endpoint should reject requests with wrong API key."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{auth_server}/sse",
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert resp.status_code == 401
+
+
+async def test_sse_accepted_with_correct_key(auth_server: str) -> None:
+    """SSE endpoint should accept requests with correct API key."""
+    async with httpx.AsyncClient() as client:
+        # SSE returns 200 with event stream
+        async with client.stream(
+            "GET",
+            f"{auth_server}/sse",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+async def test_mcp_rejected_without_auth(auth_server: str) -> None:
+    """MCP endpoint should reject requests without auth."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{auth_server}/mcp")
+        assert resp.status_code == 401
+
+
+async def test_mcp_accepted_with_correct_key(auth_server: str) -> None:
+    """MCP endpoint should accept requests with correct API key."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{auth_server}/mcp",
+            headers={
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            },
+        )
+        # Should get past auth (200 or protocol-level response, not 401)
+        assert resp.status_code != 401
+
+
+async def test_options_bypasses_auth(auth_server: str) -> None:
+    """CORS preflight (OPTIONS) should bypass auth."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.options(f"{auth_server}/sse")
+        assert resp.status_code != 401
+
+
+async def test_no_auth_configured_allows_all(noauth_server: str) -> None:
+    """When no API key is configured, all requests should pass through."""
+    async with httpx.AsyncClient() as client:
+        async with client.stream("GET", f"{noauth_server}/sse") as resp:
+            assert resp.status_code == 200
+
+
+async def test_www_authenticate_header_on_reject(auth_server: str) -> None:
+    """401 responses should include WWW-Authenticate header."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{auth_server}/sse")
+        assert resp.status_code == 401
+        assert resp.headers.get("www-authenticate") == "Bearer"
+
+
+def test_settings_api_key_field() -> None:
+    """MCPServerSettings should accept api_key parameter."""
+    settings = MCPServerSettings(
+        bind_host="127.0.0.1",
+        port=3100,
+        api_key="my-secret",
+    )
+    assert settings.api_key == "my-secret"
+
+
+def test_settings_api_key_default_none() -> None:
+    """MCPServerSettings api_key should default to None."""
+    settings = MCPServerSettings(bind_host="127.0.0.1", port=3100)
+    assert settings.api_key is None


### PR DESCRIPTION
## Summary

Add `--api-key` CLI flag and `MCP_PROXY_API_KEY` environment variable to secure all proxy endpoints with Bearer token authentication.

Addresses #108.

## Changes

- **`APIKeyMiddleware`** in `mcp_server.py` — validates `Authorization: Bearer <key>` header on all requests
- **`--api-key` CLI flag** + **`MCP_PROXY_API_KEY`** env var in `__main__.py`
- `/health`, `/status` and CORS preflight (`OPTIONS`) bypass authentication
- **Fully backward compatible**: when `--api-key` is not set, no authentication is required (existing behavior preserved)
- **12 new tests** covering all auth scenarios (valid key, missing key, wrong key, public endpoints, OPTIONS bypass)

## Design Decisions

- **Bearer token scheme** (`Authorization: Bearer <key>`) — standard HTTP auth, works with existing MCP clients that support custom headers
- **Middleware approach** — clean separation, applied before route handlers
- **Public health/status endpoints** — allows monitoring tools to check proxy status without credentials
- **No breaking changes** — auth is opt-in, zero config change needed for existing users

## Testing

```bash
pytest tests/test_api_key_auth.py -v  # 12 tests, all passing
```

Tested manually with:
- SSE transport with Bearer header → 200
- SSE without header when key is set → 401
- Health endpoint without header → 200 (bypass)
- No key configured → all requests pass (backward compat)