### PR TITLE
fix: forward serverInfo.version, instructions, websiteUrl, icons to HTTP/SSE clients

### DIFF
--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -19,7 +19,13 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
     capabilities = response.capabilities
 
     logger.debug("Configuring proxied MCP server...")
-    app: server.Server[object] = server.Server(name=response.serverInfo.name)
+    app: server.Server[object] = server.Server(
+        name=response.serverInfo.name,
+        version=response.serverInfo.version,
+        instructions=response.instructions,
+        website_url=response.serverInfo.websiteUrl,
+        icons=response.serverInfo.icons,
+    )
 
     if capabilities.prompts:
         logger.debug("Capabilities: adding Prompts...")

--- a/tests/test_proxy_server.py
+++ b/tests/test_proxy_server.py
@@ -537,3 +537,52 @@ async def test_call_tool_with_error(
 
         call_tool_result = await session.call_tool("tool", {})
         assert call_tool_result.isError
+
+
+async def test_proxy_preserves_server_metadata() -> None:
+    """The proxy must forward serverInfo (name, version, websiteUrl, icons)
+    and the top-level instructions field from the wrapped stdio server's
+    initialize response, instead of dropping everything except the name.
+
+    Regression test for sparfenyuk/mcp-proxy#206.
+    """
+    upstream_icon = types.Icon(src="https://example.invalid/icon.svg", mimeType="image/svg+xml")
+    upstream = Server(
+        "upstream-name",
+        version="1.2.3",
+        instructions="USE WHEN you need foo, bar, baz.",
+        website_url="https://example.invalid",
+        icons=[upstream_icon],
+    )
+
+    async with in_memory(upstream) as session:
+        await session.initialize()
+        wrapped = await create_proxy_server(session)
+
+    assert wrapped.name == "upstream-name"
+    assert wrapped.version == "1.2.3"
+    assert wrapped.instructions == "USE WHEN you need foo, bar, baz."
+    assert wrapped.website_url == "https://example.invalid"
+    assert wrapped.icons == [upstream_icon]
+
+
+async def test_proxy_handles_minimal_server_metadata() -> None:
+    """The proxy must also work when the wrapped server provides only a name
+    (no instructions, website_url, or icons) — the optional fields must be
+    propagated without raising.
+
+    Note: the MCP SDK auto-fills `version` from the SDK's own version when a
+    Server is constructed without one, so we don't assert version is None —
+    we just check the proxy passes whatever the upstream actually exposes.
+    """
+    upstream = Server("minimal-upstream")
+
+    async with in_memory(upstream) as session:
+        result = await session.initialize()
+        wrapped = await create_proxy_server(session)
+
+    assert wrapped.name == "minimal-upstream"
+    assert wrapped.version == result.serverInfo.version
+    assert wrapped.instructions is None
+    assert wrapped.website_url is None
+    assert wrapped.icons is None


### PR DESCRIPTION
Fixes #206.

## Summary

`create_proxy_server` in `src/mcp_proxy/proxy_server.py` was constructing the local MCP server with only `name=response.serverInfo.name` and silently dropping every other field of the wrapped stdio server's `InitializeResult`. The most consequential drop was `instructions`, which the MCP spec defines as the way an MCP server tells the client (e.g. an LLM) *when and how* to call its tools. With instructions stripped, any server that depends on a directive `instructions=` payload — search, retrieval, RAG — had to stay on stdio, which defeats mcp-proxy's reason for existing.

This PR passes through every metadata field that has a clean mapping between `InitializeResult` and `mcp.server.Server.__init__`:

| InitializeResult / Implementation | Server kwarg |
|---|---|
| `serverInfo.name`     | `name` (already passed) |
| `serverInfo.version`  | `version` |
| `instructions`        | `instructions` |
| `serverInfo.websiteUrl` | `website_url` |
| `serverInfo.icons`    | `icons` |

## Reproduction (before this PR)

A stdio MCP server that explicitly sets instructions:

```python
from mcp.server import Server
app = Server("repro-server", version="9.9.9", instructions="USE WHEN you need foo.")
```

Comparing the `initialize` response from raw stdio vs HTTP via `mcp-proxy`:

```bash
# stdio direct → instructions present
echo '{...initialize...}' | python -m repro_server | jq '.result.instructions'
# -> "USE WHEN you need foo."

# HTTP via mcp-proxy -> instructions stripped
mcp-proxy --port 8765 -- python -m repro_server &
echo '{...initialize...}' | curl -sS -X POST http://localhost:8765/mcp -d @-
# result.instructions: null  (BUG)
# result.serverInfo.version: also missing  (BUG)
```

## After this PR

End-to-end probe with the patched code:

```json
{
  "jsonrpc":"2.0","id":1,
  "result":{
    "protocolVersion":"2025-03-26",
    "capabilities":{},
    "serverInfo":{"name":"repro-server","version":"9.9.9"},
    "instructions":"USE WHEN you need foo, bar, baz."
  }
}
```

Both fields now round-trip correctly.

## Tests

Added two regression tests in `tests/test_proxy_server.py`:

- `test_proxy_preserves_server_metadata` — fully-populated upstream Server (name, version, instructions, website_url, icons). Asserts every field reaches the wrapped server.
- `test_proxy_handles_minimal_server_metadata` — bare-name upstream Server. Asserts optional fields propagate (None for instructions/website_url/icons; version comes from whatever the MCP SDK auto-fills).

Full suite still passes:

```
$ pytest tests/test_proxy_server.py -q
..........................................                               [100%]
42 passed in 1.03s
```
