### PR TITLE
fix(sse): propagate stateless flag to ServerSession in handle_sse_ins…

### DIFF
--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -103,6 +103,7 @@ def create_single_instance_routes(
                 read_stream,
                 write_stream,
                 mcp_server_instance.create_initialization_options(),
+                stateless=stateless_instance,
             )
         return Response()
 


### PR DESCRIPTION
…tance

handle_sse_instance() called mcp_server_instance.run() without stateless=stateless_instance. With SSE transport, each new ServerSession starts in InitializationState.NotInitialized, which means clients that open parallel SSE sessions (e.g. reconnects from Claude.ai Custom Connectors) can fire tool calls before `initialize` completes for that specific session, producing JSON-RPC -32602 "Invalid request parameters".

Forwarding the stateless flag matches the existing pattern in handle_streamable_http_instance and resolves the race.