### PR TITLE
fix: tolerate unknown server notifications instead of crashing TaskGroup

### DIFF
--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -21,6 +21,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import BaseRoute, Mount, Route
 from starlette.types import Receive, Scope, Send
 
+from .notification_filter import filter_unknown_notifications
 from .proxy_server import create_proxy_server
 
 logger = logging.getLogger(__name__)
@@ -176,7 +177,14 @@ async def run_mcp_server(
                 " ".join(default_server_params.args),
             )
             stdio_streams = await stack.enter_async_context(stdio_client(default_server_params))
-            session = await stack.enter_async_context(ClientSession(*stdio_streams))
+            # Drop unknown notifications (e.g. LSP-style ``window/logMessage``) before
+            # they reach ``ClientSession`` and crash the proxy via an unhandled
+            # Pydantic ``ValidationError`` inside the anyio ``TaskGroup`` wrapping
+            # ``stdio_client``. See ``notification_filter`` for details.
+            filtered_streams = await stack.enter_async_context(
+                filter_unknown_notifications(*stdio_streams),
+            )
+            session = await stack.enter_async_context(ClientSession(*filtered_streams))
             proxy = await create_proxy_server(session)
 
             instance_routes, http_manager = create_single_instance_routes(
@@ -196,7 +204,14 @@ async def run_mcp_server(
                 " ".join(params.args),
             )
             stdio_streams_named = await stack.enter_async_context(stdio_client(params))
-            session_named = await stack.enter_async_context(ClientSession(*stdio_streams_named))
+            # See note above on ``filter_unknown_notifications`` -- per-server
+            # tolerance for ``window/logMessage`` and other non-MCP notifications.
+            filtered_streams_named = await stack.enter_async_context(
+                filter_unknown_notifications(*stdio_streams_named),
+            )
+            session_named = await stack.enter_async_context(
+                ClientSession(*filtered_streams_named),
+            )
             proxy_named = await create_proxy_server(session_named)
 
             instance_routes_named, http_manager_named = create_single_instance_routes(

--- a/src/mcp_proxy/notification_filter.py
+++ b/src/mcp_proxy/notification_filter.py
@@ -1,0 +1,108 @@
+"""Filter unknown/invalid notifications from an upstream stdio MCP server.
+
+Some MCP servers in the wild (e.g. ``@21st-dev/magic``) emit JSON-RPC
+notifications with methods that are not part of the MCP ``ServerNotification``
+union -- for example LSP-style ``window/logMessage``. When such a notification
+reaches ``mcp.shared.session.BaseSession``'s receive loop, Pydantic raises a
+``ValidationError`` while parsing it. Recent versions of the ``mcp`` SDK catch
+that error inline, but older SDKs (and any future regression) let the exception
+escape the anyio ``TaskGroup`` wrapping ``stdio_client`` and crash the proxy
+process. The launchd/systemd unit then restart-loops the proxy.
+
+This module wraps the stdio read stream and silently drops any notification
+whose envelope cannot be validated as a ``ServerNotification``. A warning is
+logged with the offending method so operators can identify misbehaving servers.
+All other messages (requests, responses, errors, valid notifications) are
+forwarded unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+import anyio
+from mcp import types
+from mcp.shared.message import SessionMessage
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from anyio.streams.memory import (
+        MemoryObjectReceiveStream,
+        MemoryObjectSendStream,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+def is_known_server_notification(notification: types.JSONRPCNotification) -> bool:
+    """Return ``True`` if ``notification`` parses as a known ``ServerNotification``."""
+    try:
+        types.ServerNotification.model_validate(
+            notification.model_dump(by_alias=True, mode="json", exclude_none=True),
+        )
+    except Exception:  # noqa: BLE001 - any validation failure means "unknown"
+        return False
+    return True
+
+
+async def _pump_filtered(
+    source: MemoryObjectReceiveStream[SessionMessage | Exception],
+    sink: MemoryObjectSendStream[SessionMessage | Exception],
+) -> None:
+    """Forward messages from ``source`` to ``sink``, dropping unknown notifications."""
+    try:
+        async with sink:
+            async for item in source:
+                if (
+                    isinstance(item, SessionMessage)
+                    and isinstance(item.message.root, types.JSONRPCNotification)
+                    and not is_known_server_notification(item.message.root)
+                ):
+                    logger.warning(
+                        "Dropping unknown notification from upstream server "
+                        "(method=%r). The upstream server is emitting a "
+                        "notification outside the MCP ServerNotification union; "
+                        "this would otherwise crash the proxy via an "
+                        "unhandled Pydantic ValidationError in the anyio "
+                        "TaskGroup wrapping stdio_client.",
+                        item.message.root.method,
+                    )
+                    continue
+                await sink.send(item)
+    except anyio.ClosedResourceError:  # pragma: no cover - normal shutdown
+        return
+
+
+@asynccontextmanager
+async def filter_unknown_notifications(
+    upstream_read: MemoryObjectReceiveStream[SessionMessage | Exception],
+    upstream_write: MemoryObjectSendStream[SessionMessage],
+) -> AsyncIterator[
+    tuple[
+        MemoryObjectReceiveStream[SessionMessage | Exception],
+        MemoryObjectSendStream[SessionMessage],
+    ]
+]:
+    """Wrap stdio streams so unknown server notifications are logged and dropped.
+
+    Usage mirrors ``stdio_client``: the context manager yields a
+    ``(read_stream, write_stream)`` pair that can be handed straight to
+    :class:`mcp.client.session.ClientSession`. The write stream is passed
+    through unchanged; only the read side is filtered.
+    """
+    downstream_write, downstream_read = anyio.create_memory_object_stream[
+        SessionMessage | Exception
+    ](0)
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_pump_filtered, upstream_read, downstream_write)
+        try:
+            yield downstream_read, upstream_write
+        finally:
+            await downstream_read.aclose()
+            tg.cancel_scope.cancel()
+
+
+__all__ = ["filter_unknown_notifications", "is_known_server_notification"]

--- a/tests/test_notification_filter.py
+++ b/tests/test_notification_filter.py
@@ -1,0 +1,204 @@
+"""Tests for ``mcp_proxy.notification_filter``.
+
+These tests cover the scenario where an upstream MCP server emits a JSON-RPC
+notification with a ``method`` that is not part of the MCP
+``ServerNotification`` union (for example LSP-style ``window/logMessage``).
+
+Without the filter, the unknown notification reaches
+``mcp.shared.session.BaseSession`` and Pydantic raises a ``ValidationError``
+that, on older versions of the ``mcp`` SDK, escapes the anyio ``TaskGroup``
+wrapping ``stdio_client`` and crashes the proxy process.
+
+The filter must:
+
+* Drop unknown notifications (and log a warning) so the proxy stays up.
+* Forward known notifications untouched (e.g. ``ProgressNotification``).
+* Forward requests / responses untouched.
+* Tear down cleanly on context exit without leaking tasks.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import anyio
+import pytest
+from mcp import types
+from mcp.shared.message import SessionMessage
+
+from mcp_proxy.notification_filter import (
+    filter_unknown_notifications,
+    is_known_server_notification,
+)
+
+if TYPE_CHECKING:
+    from anyio.streams.memory import MemoryObjectReceiveStream
+
+
+def _make_session_message(payload: dict[str, object]) -> SessionMessage:
+    """Wrap ``payload`` as a JSON-RPC ``SessionMessage`` exactly as ``stdio_client`` would."""
+    return SessionMessage(types.JSONRPCMessage.model_validate(payload))
+
+
+def test_is_known_server_notification_accepts_progress() -> None:
+    """A standard MCP ``ProgressNotification`` envelope is recognised as known."""
+    notification = types.JSONRPCNotification(
+        jsonrpc="2.0",
+        method="notifications/progress",
+        params={"progressToken": 1, "progress": 0.5, "total": 1.0},
+    )
+    assert is_known_server_notification(notification) is True
+
+
+def test_is_known_server_notification_rejects_lsp_log() -> None:
+    """An LSP-style ``window/logMessage`` notification is recognised as unknown."""
+    notification = types.JSONRPCNotification(
+        jsonrpc="2.0",
+        method="window/logMessage",
+        params={"type": 3, "message": "hello from a misbehaving server"},
+    )
+    assert is_known_server_notification(notification) is False
+
+
+@pytest.mark.anyio
+async def test_filter_drops_unknown_notification_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown notifications are dropped from the read stream and surface as a warning."""
+    upstream_write_to_proxy, upstream_read_into_proxy = anyio.create_memory_object_stream[
+        SessionMessage | Exception
+    ](0)
+    proxy_write_to_upstream, _proxy_read_from_upstream = anyio.create_memory_object_stream[
+        SessionMessage
+    ](0)
+
+    bad = _make_session_message(
+        {
+            "jsonrpc": "2.0",
+            "method": "window/logMessage",
+            "params": {"type": 3, "message": "noise"},
+        },
+    )
+    good = _make_session_message(
+        {
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": {"progressToken": 7, "progress": 0.25, "total": 1.0},
+        },
+    )
+
+    received: list[SessionMessage | Exception] = []
+
+    async def producer() -> None:
+        async with upstream_write_to_proxy:
+            await upstream_write_to_proxy.send(bad)
+            await upstream_write_to_proxy.send(good)
+
+    async def consumer(
+        stream: MemoryObjectReceiveStream[SessionMessage | Exception],
+    ) -> None:
+        received.extend([item async for item in stream])
+
+    caplog.set_level(logging.WARNING, logger="mcp_proxy.notification_filter")
+
+    async with anyio.create_task_group() as tg, filter_unknown_notifications(
+        upstream_read_into_proxy,
+        proxy_write_to_upstream,
+    ) as (filtered_read, _filtered_write):
+        tg.start_soon(producer)
+        tg.start_soon(consumer, filtered_read)
+        await anyio.sleep(0.05)
+        await filtered_read.aclose()
+
+    assert len(received) == 1, "the unknown notification must be dropped"
+    assert isinstance(received[0], SessionMessage)
+    assert isinstance(received[0].message.root, types.JSONRPCNotification)
+    assert received[0].message.root.method == "notifications/progress"
+
+    assert any(
+        "window/logMessage" in record.getMessage() for record in caplog.records
+    ), "filter must log the dropped notification's method"
+
+
+@pytest.mark.anyio
+async def test_filter_passes_requests_and_responses_through() -> None:
+    """Non-notification frames (requests, responses, errors) pass through unchanged."""
+    upstream_write_to_proxy, upstream_read_into_proxy = anyio.create_memory_object_stream[
+        SessionMessage | Exception
+    ](0)
+    proxy_write_to_upstream, _ = anyio.create_memory_object_stream[SessionMessage](0)
+
+    request = _make_session_message(
+        {"jsonrpc": "2.0", "id": 1, "method": "ping", "params": None},
+    )
+    response = _make_session_message(
+        {"jsonrpc": "2.0", "id": 1, "result": {}},
+    )
+
+    received: list[SessionMessage | Exception] = []
+
+    async def producer() -> None:
+        async with upstream_write_to_proxy:
+            await upstream_write_to_proxy.send(request)
+            await upstream_write_to_proxy.send(response)
+
+    async def consumer(
+        stream: MemoryObjectReceiveStream[SessionMessage | Exception],
+    ) -> None:
+        received.extend([item async for item in stream])
+
+    async with anyio.create_task_group() as tg, filter_unknown_notifications(
+        upstream_read_into_proxy,
+        proxy_write_to_upstream,
+    ) as (filtered_read, _filtered_write):
+        tg.start_soon(producer)
+        tg.start_soon(consumer, filtered_read)
+        await anyio.sleep(0.05)
+        await filtered_read.aclose()
+
+    assert len(received) == 2  # noqa: PLR2004 - request + response
+    assert all(isinstance(item, SessionMessage) for item in received)
+
+
+@pytest.mark.anyio
+async def test_filter_survives_burst_of_unknown_notifications() -> None:
+    """A flood of unknown notifications must not crash the filter or its parent task group."""
+    upstream_write_to_proxy, upstream_read_into_proxy = anyio.create_memory_object_stream[
+        SessionMessage | Exception
+    ](0)
+    proxy_write_to_upstream, _ = anyio.create_memory_object_stream[SessionMessage](0)
+
+    burst = [
+        _make_session_message(
+            {
+                "jsonrpc": "2.0",
+                "method": "window/logMessage",
+                "params": {"type": 3, "message": f"noise #{i}"},
+            },
+        )
+        for i in range(50)
+    ]
+
+    received: list[SessionMessage | Exception] = []
+
+    async def producer() -> None:
+        async with upstream_write_to_proxy:
+            for item in burst:
+                await upstream_write_to_proxy.send(item)
+
+    async def consumer(
+        stream: MemoryObjectReceiveStream[SessionMessage | Exception],
+    ) -> None:
+        received.extend([item async for item in stream])
+
+    async with anyio.create_task_group() as tg, filter_unknown_notifications(
+        upstream_read_into_proxy,
+        proxy_write_to_upstream,
+    ) as (filtered_read, _filtered_write):
+        tg.start_soon(producer)
+        tg.start_soon(consumer, filtered_read)
+        await anyio.sleep(0.05)
+        await filtered_read.aclose()
+
+    assert received == []


### PR DESCRIPTION
## Problem

Some MCP servers in the wild emit JSON-RPC notifications with methods that are **not** part of the MCP `ServerNotification` union. A concrete example is `@21st-dev/magic` v0.0.46, which emits LSP-style `window/logMessage`:

```json
{"jsonrpc":"2.0","method":"window/logMessage","params":{"type":3,"message":"..."}}
```

When such a notification reaches `mcp.shared.session.BaseSession`'s receive loop, Pydantic raises a `ValidationError` while parsing it against the `ServerNotification` discriminated union. If that exception escapes the anyio `TaskGroup` wrapping `stdio_client`, the proxy dies with:

```
ExceptionGroup: unhandled errors in a TaskGroup
  +-+- ValidationError: ... ServerNotification ...
```

…and the supervisor (`launchd` / `systemd`) restart-loops the proxy, which interrupts every bridged session every few seconds.

We hit this in production with `@21st-dev/magic` bridged via mcp-proxy. Recent `mcp` SDKs catch the error inline at one site (`shared/session.py`), but the proxy currently has no defense of its own, so any future SDK regression or any code path that re-raises will crash the whole process.

## Fix

Add a small, surgical defense **at the proxy boundary** so we are robust regardless of what the upstream SDK does:

- New module `src/mcp_proxy/notification_filter.py` wraps the stdio read stream and drops any notification whose envelope cannot be validated as a `ServerNotification`. A `WARNING` is logged with the offending method so operators can identify the misbehaving upstream server.
- `mcp_server.run_mcp_server` wires the filter in front of every `ClientSession` (both the default server and every named server).

### Behaviour

| Frame | Before | After |
|---|---|---|
| `window/logMessage` (and other unknown notifications) | crashes proxy via `TaskGroup` | logged + dropped, proxy stays up |
| `notifications/progress` and other known notifications | forwarded | forwarded (unchanged) |
| Requests / responses / errors | forwarded | forwarded (unchanged) |

The write stream is passed through untouched; only the read side is filtered.

## Tests

`tests/test_notification_filter.py` adds 5 focused tests:

1. `is_known_server_notification` accepts a real `ProgressNotification`.
2. `is_known_server_notification` rejects `window/logMessage`.
3. End-to-end: `window/logMessage` is dropped from the filtered stream **and** a warning is logged that names the method.
4. End-to-end: a `ping` request and its response pass through unchanged.
5. Burst: 50 unknown notifications in a row never crash the surrounding `anyio.TaskGroup`.

### Results

```
tests/test_cli_arguments.py ..........              [ 10%]
tests/test_config_loader.py .............           [ 22%]
tests/test_mcp_server.py ................           [ 39%]
tests/test_notification_filter.py .....             [ 44%]
tests/test_progress_forwarding.py ......            [ 50%]
tests/test_proxy_server.py ..............................................  [100%]

======================== 97 passed, 3 warnings in 1.37s ========================
```

`ruff check src/ tests/` → clean. `mypy` on the three touched files → clean. (The 53 pre-existing mypy errors in `tests/test_mcp_server.py` are untouched.)

## Diff summary

```
 src/mcp_proxy/mcp_server.py          |  19 +++-
 src/mcp_proxy/notification_filter.py | 108 +++++++++++++++++++
 tests/test_notification_filter.py    | 204 +++++++++++++++++++++++++++++++++++
 3 files changed, 329 insertions(+), 2 deletions(-)
```

## Notes

- The filter only drops *unknown* notifications — `notifications/progress`, `notifications/message`, `notifications/resources/updated`, etc. all flow through unchanged.
- We deliberately do **not** rewrite or coerce the offending notification; the goal is robustness, not silently re-interpreting upstream semantics. The warning log makes it easy to file an issue against the upstream MCP server.
- No new runtime dependencies.