### PR TITLE
fix: forward server instructions through proxy

### DIFF
--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -20,7 +20,7 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
     capabilities = response.capabilities
 
     logger.debug("Configuring proxied MCP server...")
-    app: server.Server[object] = server.Server(name=response.serverInfo.name)
+    app: server.Server[object] = server.Server(name=response.serverInfo.name, instructions=response.instructions)
 
     if capabilities.prompts:
         logger.debug("Capabilities: adding Prompts...")


### PR DESCRIPTION
The proxy creates its own `Server` instance to relay capabilities from downstream MCP servers but was not forwarding the `instructions` field from the downstream server's `initialize` response.

This meant any MCP server behind `mcp-proxy` had its `instructions` silently dropped -- connecting clients never received them.

### Fix

Pass `response.instructions` through to the `Server` constructor, which already accepts it and wires it into `create_initialization_options()`.

```diff
- app: server.Server[object] = server.Server(name=response.serverInfo.name)
+ app: server.Server[object] = server.Server(name=response.serverInfo.name, instructions=response.instructions)
```

No behavior change when `instructions` is `None` (the default).