### PR TITLE
fix: advertise Streamable HTTP endpoints and add Xquik example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,33 @@ For Claude Desktop, the configuration entry can look like this:
 }
 ```
 
+For a Streamable HTTP server that expects a bearer token, pass
+`--transport=streamablehttp` and the header pair. For example, Xquik exposes a
+remote MCP endpoint for X data workflows:
+
+```json
+{
+  "mcpServers": {
+    "xquik": {
+      "command": "mcp-proxy",
+      "args": [
+        "--transport=streamablehttp",
+        "--headers",
+        "Authorization",
+        "Bearer YOUR_XQUIK_API_KEY",
+        "https://xquik.com/mcp"
+      ]
+    }
+  }
+}
+```
+
+See the [Xquik MCP guide](https://docs.xquik.com/mcp/overview) for available
+tools and authentication options.
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.
+
 ## 2. SSE to stdio
 
 Run a proxy server exposing a SSE server that connects to a local stdio server.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   - [1. stdio to SSE/StreamableHTTP](#1-stdio-to-ssestreamablehttp)
     - [1.1 Configuration](#11-configuration)
     - [1.2 Example usage](#12-example-usage)
-  - [2. SSE to stdio](#2-sse-to-stdio)
+  - [2. SSE/StreamableHTTP to stdio](#2-ssestreamablehttp-to-stdio)
     - [2.1 Configuration](#21-configuration)
     - [2.2 Example usage](#22-example-usage)
   - [Named Servers](#named-servers)
@@ -119,16 +119,18 @@ tools and authentication options.
 Xquik is an independent third-party service. Not affiliated with X Corp.
 "Twitter" and "X" are trademarks of X Corp.
 
-## 2. SSE to stdio
+## 2. SSE/StreamableHTTP to stdio
 
-Run a proxy server exposing a SSE server that connects to a local stdio server.
+Run a proxy server exposing SSE and Streamable HTTP endpoints that connect to a
+local stdio server.
 
-This allows remote connections to the local stdio server. The `mcp-proxy` opens a port to listen for SSE requests,
-spawns a local stdio server that handles MCP requests.
+This allows remote connections to the local stdio server. The `mcp-proxy` opens
+a port for SSE and Streamable HTTP requests, then spawns a local stdio server
+that handles MCP requests.
 
 ```mermaid
 graph LR
-    A["LLM Client"] <-->|SSE| B["mcp-proxy"]
+    A["LLM Client"] <-->|SSE / Streamable HTTP| B["mcp-proxy"]
     B <-->|stdio| C["Local MCP Server"]
 
     style A fill:#ffe6f9,stroke:#333,color:black,stroke-width:2px
@@ -138,10 +140,11 @@ graph LR
 
 ### 2.1 Configuration
 
-This mode requires the `--sse-port` argument to be set. The `--sse-host` argument can be set to specify the host IP
-address that the SSE server will listen on. Additional environment variables can be passed to the local stdio server
-using the `--env` argument. The command line arguments for the local stdio server must be passed after the `--`
-separator.
+Use `--port` to set a fixed port and `--host` to set the listening address.
+Each configured server exposes both an SSE endpoint and a Streamable HTTP
+endpoint. Additional environment variables can be passed to the local stdio
+server using the `--env` argument. The command line arguments for the local
+stdio server must be passed after the `--` separator.
 
 Arguments
 
@@ -200,9 +203,13 @@ mcp-proxy --port=8080 --allow-origin='*' --expose-header Custom-Header uvx mcp-s
   - This argument is ignored if `--named-server-config` is used.
 - `FILE_PATH` - If provided, this is the exclusive source for named servers, and `--named-server` CLI arguments are ignored.
 
-If a default server is specified (the `command_or_url` argument without `--named-server` or `--named-server-config`), it will be accessible at the root paths (e.g., `http://127.0.0.1:8080/sse`).
+If a default server is specified (the `command_or_url` argument without
+`--named-server` or `--named-server-config`), it will be accessible at
+`/sse` and `/mcp` (for example, `http://127.0.0.1:8080/mcp`).
 
-Named servers (whether defined by `--named-server` or `--named-server-config`) will be accessible under `/servers/<server-name>/` (e.g., `http://127.0.0.1:8080/servers/fetch1/sse`).
+Named servers (whether defined by `--named-server` or `--named-server-config`)
+will expose `/servers/<server-name>/sse` and `/servers/<server-name>/mcp`
+(for example, `http://127.0.0.1:8080/servers/fetch1/mcp`).
 The `/status` endpoint provides global status.
 
 **JSON Configuration File Format for `--named-server-config`:**

--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Final, Literal
@@ -30,6 +30,22 @@ DEFAULT_EXPOSE_HEADERS: Final[tuple[str, ...]] = ("mcp-session-id",)
 
 def _default_expose_headers() -> list[str]:
     return list(DEFAULT_EXPOSE_HEADERS)
+
+
+def _server_endpoint_urls(
+    base_url: str,
+    *,
+    has_default_server: bool,
+    named_server_names: Iterable[str],
+) -> list[tuple[str, str]]:
+    server_paths = [""] if has_default_server else []
+    server_paths.extend(f"/servers/{name}" for name in named_server_names)
+
+    return [
+        (transport, f"{base_url}{server_path}{endpoint_path}")
+        for server_path in server_paths
+        for transport, endpoint_path in (("SSE", "/sse"), ("Streamable HTTP", "/mcp"))
+    ]
 
 
 @dataclass
@@ -245,23 +261,19 @@ async def run_mcp_server(
         )
         http_server = uvicorn.Server(config)
 
-        # Print out the SSE URLs for all configured servers
+        # Print out the URLs for all configured servers
         base_url = f"http://{mcp_settings.bind_host}:{mcp_settings.port}"
-        sse_urls = []
+        endpoint_urls = _server_endpoint_urls(
+            base_url,
+            has_default_server=default_server_params is not None,
+            named_server_names=named_server_params,
+        )
 
-        # Add default server if configured
-        if default_server_params:
-            sse_urls.append(f"{base_url}/sse")
-
-        # Add named servers
-        sse_urls.extend([f"{base_url}/servers/{name}/sse" for name in named_server_params])
-
-        # Display the SSE URLs prominently
-        if sse_urls:
-            # Using print directly for user visibility, with noqa to ignore linter warnings
-            logger.info("Serving MCP Servers via SSE:")
-            for url in sse_urls:
-                logger.info("  - %s", url)
+        # Display the endpoint URLs prominently
+        if endpoint_urls:
+            logger.info("Serving MCP Servers:")
+            for transport, url in endpoint_urls:
+                logger.info("  - %s: %s", transport, url)
 
         logger.debug(
             "Serving incoming MCP requests on %s:%s",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,7 +4,7 @@
 import asyncio
 import contextlib
 import typing as t
-from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
+from unittest.mock import AsyncMock, MagicMock, call, create_autospec, patch
 
 import pytest
 import uvicorn
@@ -624,11 +624,11 @@ async def test_run_mcp_server_global_status_updates(
         assert _global_status["server_instances"]["test_server"] == "configured"
 
 
-async def test_run_mcp_server_sse_url_logging(
+async def test_run_mcp_server_transport_url_logging(
     mock_settings: MCPServerSettings,
     mock_stdio_params: StdioServerParameters,
 ) -> None:
-    """Test run_mcp_server logs correct SSE URLs."""
+    """Test run_mcp_server logs both transport URLs."""
     named_servers = {"test_server": mock_stdio_params}
 
     with (
@@ -656,15 +656,20 @@ async def test_run_mcp_server_sse_url_logging(
         # Run the function
         await run_mcp_server(mock_settings, mock_stdio_params, named_servers)
 
-        # Verify SSE URLs were logged
-        expected_default_url = f"http://{mock_settings.bind_host}:{mock_settings.port}/sse"
-        expected_named_url = (
-            f"http://{mock_settings.bind_host}:{mock_settings.port}/servers/test_server/sse"
+        base_url = f"http://{mock_settings.bind_host}:{mock_settings.port}"
+        mock_logger.info.assert_has_calls(
+            [
+                call("Serving MCP Servers:"),
+                call("  - %s: %s", "SSE", f"{base_url}/sse"),
+                call("  - %s: %s", "Streamable HTTP", f"{base_url}/mcp"),
+                call("  - %s: %s", "SSE", f"{base_url}/servers/test_server/sse"),
+                call(
+                    "  - %s: %s",
+                    "Streamable HTTP",
+                    f"{base_url}/servers/test_server/mcp",
+                ),
+            ],
         )
-
-        mock_logger.info.assert_any_call("Serving MCP Servers via SSE:")
-        mock_logger.info.assert_any_call("  - %s", expected_default_url)
-        mock_logger.info.assert_any_call("  - %s", expected_named_url)
 
 
 async def test_run_mcp_server_exception_handling(


### PR DESCRIPTION
## Summary

- Add a Claude Desktop example for Xquik's Streamable HTTP MCP endpoint.
- Document Xquik authentication, product guidance, and independence.
- Advertise both SSE and Streamable HTTP URLs at startup.
- Document both endpoint types for default and named servers.
- Add regression coverage for every advertised endpoint.

Fixes #211.

## Validation

- `uv run --frozen coverage run -m pytest` (92 passed)
- `uv run --frozen coverage report --fail-under 83` (87.64%)
- `uvx --from ruff==0.15.13 ruff check src tests`
- `uvx --from ruff==0.15.13 ruff format --check src tests`
- `uv run --frozen mypy --python-version 3.14 src`
- `git diff --check`
- Verified `https://xquik.com/mcp` returns the expected unauthenticated 401.
- Verified the live Xquik MCP manifest declares Streamable HTTP.
