### PR TITLE
HTTP/HTTPS Proxy support

### DIFF
--- a/src/mcp_proxy/httpx_client.py
+++ b/src/mcp_proxy/httpx_client.py
@@ -38,6 +38,11 @@ def custom_httpx_client(  # noqa: C901
         "follow_redirects": True,
     }
 
+    # Dynamically load proxy from environment variables
+    proxy_url = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+    if proxy_url:
+        kwargs["proxy"] = proxy_url
+
     # Handle timeout
     if timeout is None:
         kwargs["timeout"] = httpx.Timeout(30.0)


### PR DESCRIPTION
Adds http/https proxy support. Reads settings from environment variables HTTP_PROXY/HTTPS_PROXY

Tested to work in LM Studio with this config:
```json
{
  "mcpServers": {
    "mcp-proxy-example": {
      "command": "mcp-proxy",
      "args": [
        "https://example.com/mcp"
      ],
      "env": {
        "HTTP_PROXY": "http://localhost:1234"
      }
    }
  }
}
```


Disclaimer: LLM assisted (Qwen3.6 27b)