### PR TITLE
fix: prevent SSE runtime disconnect from crashing entire proxy

### DIFF
--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -93,17 +93,26 @@ def create_single_instance_routes(
     )
 
     async def handle_sse_instance(request: Request) -> Response:
-        async with sse_transport.connect_sse(
-            request.scope,
-            request.receive,
-            request._send,  # noqa: SLF001
-        ) as (read_stream, write_stream):
-            _update_global_activity()
-            await mcp_server_instance.run(
-                read_stream,
-                write_stream,
-                mcp_server_instance.create_initialization_options(),
-                stateless=stateless_instance,
+        try:
+            async with sse_transport.connect_sse(
+                request.scope,
+                request.receive,
+                request._send,  # noqa: SLF001
+            ) as (read_stream, write_stream):
+                _update_global_activity()
+                await mcp_server_instance.run(
+                    read_stream,
+                    write_stream,
+                    mcp_server_instance.create_initialization_options(),
+                    stateless=stateless_instance,
+                )
+        except Exception:
+            # SSE response already started — cannot send HTTP error response.
+            # Log and let the connection close gracefully.
+            logger.warning(
+                "SSE connection for '%s' terminated with error (upstream disconnect?)",
+                mcp_server_instance.name,
+                exc_info=True,
             )
         return Response()
 


### PR DESCRIPTION
## Problem

When an upstream MCP server's SSE connection drops mid-session, the exception propagates from `handle_sse_instance` to Starlette's `wrap_app_handling_exceptions`, which tries to send an HTTP error response. But the SSE response has already started, so uvicorn rejects the duplicate `http.response.start`:

```
RuntimeError: Expected ASGI message 'http.response.body', but got 'http.response.start'.
```

This crashes the entire mcp-proxy process, taking down ALL named servers.

Closes #230

## Root Cause

`handle_sse_instance` in `mcp_server.py` has no exception handling. When `mcp_server_instance.run()` raises inside `async with sse_transport.connect_sse()`, the exception escapes to Starlette's error middleware.

## Fix

Wrap `handle_sse_instance` in try/except: log the error and return gracefully. The SSE transport handles the response lifecycle internally.

## Related

- #198 (startup failures) was fixed in PR #213, but runtime SSE disconnects remained unhandled
- This is a known pattern in SSE-over-ASGI bridges