### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mcp-proxy
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fsparfenyuk%2Fmcp-proxy.svg)](https://mcptoplist.com/server/glama%2Fsparfenyuk%2Fmcp-proxy)
+
 ![GitHub License](https://img.shields.io/github/license/sparfenyuk/mcp-proxy)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mcp-proxy)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/mcp-proxy)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,686 MCP servers across the major
registries, and **MCP Proxy Server** is currently ranked **#909**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fsparfenyuk%2Fmcp-proxy.svg)](https://mcptoplist.com/server/glama%2Fsparfenyuk%2Fmcp-proxy)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building MCP Proxy Server!
