### PR TITLE
build: cap mcp dependency to <2 (fixes #235)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 version = "0.12.0"
 requires-python = ">=3.10"
-dependencies = ["httpx-auth>=0.23.1", "mcp>=1.27.1", "uvicorn>=0.47.0"]
+dependencies = ["httpx-auth>=0.23.1", "mcp>=1.27.1,<2", "uvicorn>=0.47.0"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
**Problem**

`mcp-proxy` declares an unbounded `mcp>=1.27.1`. `mcp` 2.0.0 removed `request_ctx` from `mcp.server.lowlevel.server`, which `src/mcp_proxy/proxy_server.py` imports at module load. As a result, any fresh resolution (`uvx mcp-proxy`, a clean `pip install`, or a Docker rebuild) pulls `mcp==2.0.0` and crashes on startup:

```
ImportError: cannot import name 'request_ctx' from 'mcp.server.lowlevel.server'
```

This matches the report in #235.

**Fix**

Cap the dependency at `mcp>=1.27.1,<2` so resolution stays on the 1.x line that still provides `request_ctx`. This is the minimal change that restores a working install; it does **not** add support for `mcp` 2.x (that would require migrating `proxy_server.py` off the removed `request_ctx` API and can be a follow-up). The cap can be lifted/raised once the code targets the 2.x request-context API.

Verified locally (alpine 3.24, Python 3.14, mcp-proxy 0.12.0):

- without the cap → resolves `mcp==2.0.0` → `import mcp_proxy.proxy_server` raises the ImportError above
- with the cap → resolves `mcp==1.29.0` → import succeeds

Closes #235.
