### PR TITLE
fix: forward pagination params in proxy list handlers

### DIFF
--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -25,8 +25,8 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
     if capabilities.prompts:
         logger.debug("Capabilities: adding Prompts...")
 
-        async def _list_prompts(_: t.Any) -> types.ServerResult:  # noqa: ANN401
-            result = await remote_app.list_prompts()
+        async def _list_prompts(req: types.ListPromptsRequest) -> types.ServerResult:
+            result = await remote_app.list_prompts(params=req.params)
             return types.ServerResult(result)
 
         app.request_handlers[types.ListPromptsRequest] = _list_prompts
@@ -40,14 +40,16 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
     if capabilities.resources:
         logger.debug("Capabilities: adding Resources...")
 
-        async def _list_resources(_: t.Any) -> types.ServerResult:  # noqa: ANN401
-            result = await remote_app.list_resources()
+        async def _list_resources(req: types.ListResourcesRequest) -> types.ServerResult:
+            result = await remote_app.list_resources(params=req.params)
             return types.ServerResult(result)
 
         app.request_handlers[types.ListResourcesRequest] = _list_resources
 
-        async def _list_resource_templates(_: t.Any) -> types.ServerResult:  # noqa: ANN401
-            result = await remote_app.list_resource_templates()
+        async def _list_resource_templates(
+            req: types.ListResourceTemplatesRequest,
+        ) -> types.ServerResult:
+            result = await remote_app.list_resource_templates(params=req.params)
             return types.ServerResult(result)
 
         app.request_handlers[types.ListResourceTemplatesRequest] = _list_resource_templates
@@ -85,8 +87,10 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
     if capabilities.tools:
         logger.debug("Capabilities: adding Tools...")
 
-        async def _list_tools(_: t.Any) -> types.ServerResult:  # noqa: ANN401
-            tools = await remote_app.list_tools()
+        async def _list_tools(req: t.Any) -> types.ServerResult:  # noqa: ANN401
+            tools = await remote_app.list_tools(
+                params=req.params if req is not None else None,
+            )
             return types.ServerResult(tools)
 
         app.request_handlers[types.ListToolsRequest] = _list_tools

--- a/tests/test_proxy_server.py
+++ b/tests/test_proxy_server.py
@@ -25,6 +25,7 @@ from pydantic import AnyUrl
 from mcp_proxy.proxy_server import create_proxy_server
 
 TOOL_INPUT_SCHEMA = {"type": "object", "properties": {"input1": {"type": "string"}}}
+PAGINATION_CURSOR = "page-2"
 
 SessionContextManager = Callable[[Server[object]], AbstractAsyncContextManager[ClientSession]]
 
@@ -382,6 +383,175 @@ async def test_list_resource_templates(
 
         list_resources_result = await session.list_resource_templates()
         assert list_resources_result.resourceTemplates == [resource_template]
+
+
+async def test_list_prompts_pagination(
+    session_generator: SessionContextManager,
+    server: Server[object],
+) -> None:
+    """Test that prompts/list pagination is preserved through the proxy."""
+    first_prompt = types.Prompt(name="prompt-page-1")
+    second_prompt = types.Prompt(name="prompt-page-2")
+    observed_cursors: list[str | None] = []
+
+    @server.list_prompts()  # type: ignore[no-untyped-call,misc]
+    async def _list_prompts(req: types.ListPromptsRequest) -> types.ListPromptsResult:
+        cursor = req.params.cursor if req.params is not None else None
+        observed_cursors.append(cursor)
+        if cursor == PAGINATION_CURSOR:
+            return types.ListPromptsResult(prompts=[second_prompt])
+        return types.ListPromptsResult(
+            prompts=[first_prompt],
+            nextCursor=PAGINATION_CURSOR,
+        )
+
+    async with session_generator(server) as session:
+        await session.initialize()
+
+        first_result = await session.list_prompts()
+        second_result = await session.list_prompts(
+            params=types.PaginatedRequestParams(cursor=PAGINATION_CURSOR),
+        )
+
+        assert first_result.prompts == [first_prompt]
+        assert first_result.nextCursor == PAGINATION_CURSOR
+        assert observed_cursors == [None, PAGINATION_CURSOR]
+        assert second_result.prompts == [second_prompt]
+        assert second_result.nextCursor is None
+
+
+async def test_list_resources_pagination(
+    session_generator: SessionContextManager,
+    server: Server[object],
+) -> None:
+    """Test that resources/list pagination is preserved through the proxy."""
+    first_resource = types.Resource(
+        uri=AnyUrl("scheme://resource-page-1"),
+        name="resource-page-1",
+    )
+    second_resource = types.Resource(
+        uri=AnyUrl("scheme://resource-page-2"),
+        name="resource-page-2",
+    )
+    observed_cursors: list[str | None] = []
+
+    @server.list_resources()  # type: ignore[no-untyped-call,misc]
+    async def _list_resources(req: types.ListResourcesRequest) -> types.ListResourcesResult:
+        cursor = req.params.cursor if req.params is not None else None
+        observed_cursors.append(cursor)
+        if cursor == PAGINATION_CURSOR:
+            return types.ListResourcesResult(resources=[second_resource])
+        return types.ListResourcesResult(
+            resources=[first_resource],
+            nextCursor=PAGINATION_CURSOR,
+        )
+
+    async with session_generator(server) as session:
+        await session.initialize()
+
+        first_result = await session.list_resources()
+        second_result = await session.list_resources(
+            params=types.PaginatedRequestParams(cursor=PAGINATION_CURSOR),
+        )
+
+        assert first_result.resources == [first_resource]
+        assert first_result.nextCursor == PAGINATION_CURSOR
+        assert observed_cursors == [None, PAGINATION_CURSOR]
+        assert second_result.resources == [second_resource]
+        assert second_result.nextCursor is None
+
+
+async def test_list_resource_templates_pagination(
+    session_generator: SessionContextManager,
+    server: Server[object],
+) -> None:
+    """Test that resources/templates/list pagination is preserved through the proxy."""
+    first_template = types.ResourceTemplate(
+        uriTemplate="scheme://resource/{page_1}",
+        name="resource-template-page-1",
+    )
+    second_template = types.ResourceTemplate(
+        uriTemplate="scheme://resource/{page_2}",
+        name="resource-template-page-2",
+    )
+    observed_cursors: list[str | None] = []
+
+    @server.list_resources()  # type: ignore[no-untyped-call,misc]
+    async def _list_resources() -> list[types.Resource]:
+        return []
+
+    async def _list_resource_templates(
+        req: types.ListResourceTemplatesRequest,
+    ) -> types.ServerResult:
+        cursor = req.params.cursor if req.params is not None else None
+        observed_cursors.append(cursor)
+        if cursor == PAGINATION_CURSOR:
+            result = types.ListResourceTemplatesResult(
+                resourceTemplates=[second_template],
+            )
+        else:
+            result = types.ListResourceTemplatesResult(
+                resourceTemplates=[first_template],
+                nextCursor=PAGINATION_CURSOR,
+            )
+        return types.ServerResult(result)
+
+    server.request_handlers[types.ListResourceTemplatesRequest] = _list_resource_templates
+
+    async with session_generator(server) as session:
+        await session.initialize()
+
+        first_result = await session.list_resource_templates()
+        second_result = await session.list_resource_templates(
+            params=types.PaginatedRequestParams(cursor=PAGINATION_CURSOR),
+        )
+
+        assert first_result.resourceTemplates == [first_template]
+        assert first_result.nextCursor == PAGINATION_CURSOR
+        assert observed_cursors == [None, PAGINATION_CURSOR]
+        assert second_result.resourceTemplates == [second_template]
+        assert second_result.nextCursor is None
+
+
+async def test_list_tools_pagination(
+    session_generator: SessionContextManager,
+    server: Server[object],
+) -> None:
+    """Test that tools/list pagination is preserved through the proxy."""
+    first_tool = types.Tool(
+        name="tool-page-1",
+        inputSchema=TOOL_INPUT_SCHEMA,
+    )
+    second_tool = types.Tool(
+        name="tool-page-2",
+        inputSchema=TOOL_INPUT_SCHEMA,
+    )
+    observed_cursors: list[str | None] = []
+
+    @server.list_tools()  # type: ignore[no-untyped-call,misc]
+    async def _list_tools(req: types.ListToolsRequest) -> types.ListToolsResult:
+        cursor = req.params.cursor if req.params is not None else None
+        observed_cursors.append(cursor)
+        if cursor == PAGINATION_CURSOR:
+            return types.ListToolsResult(tools=[second_tool])
+        return types.ListToolsResult(
+            tools=[first_tool],
+            nextCursor=PAGINATION_CURSOR,
+        )
+
+    async with session_generator(server) as session:
+        await session.initialize()
+
+        first_result = await session.list_tools()
+        second_result = await session.list_tools(
+            params=types.PaginatedRequestParams(cursor=PAGINATION_CURSOR),
+        )
+
+        assert first_result.tools == [first_tool]
+        assert first_result.nextCursor == PAGINATION_CURSOR
+        assert observed_cursors == [None, PAGINATION_CURSOR]
+        assert second_result.tools == [second_tool]
+        assert second_result.nextCursor is None
 
 
 @pytest.mark.parametrize("prompt_callback", [AsyncMock()])


### PR DESCRIPTION
## Summary

- forward complete pagination request parameters through prompts, resources, resource templates, and tools list handlers
- preserve the tools handler's internal `None` request path
- add direct/proxy in-memory regression coverage for cursor forwarding and `nextCursor`

Fixes #233

## Validation

- pre-commit hooks passed, including Ruff lint and format
- mypy passed for all 8 source files
- full test suite passed on Python 3.10, 3.11, 3.12, and 3.13 (`100 passed` each)
- coverage passed at 88.75% against the required 83%
