### PR TITLE
feat: report active SSE connection count in /status

### DIFF
--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -47,6 +47,7 @@ class MCPServerSettings:
 # To store last activity for multiple servers if needed, though status endpoint is global for now.
 _global_status: dict[str, Any] = {
     "api_last_activity": datetime.now(timezone.utc).isoformat(),
+    "active_sse_connections": 0,
     "server_instances": {},  # Could be used to store per-instance status later
 }
 
@@ -99,12 +100,16 @@ def create_single_instance_routes(
             request._send,  # noqa: SLF001
         ) as (read_stream, write_stream):
             _update_global_activity()
-            await mcp_server_instance.run(
-                read_stream,
-                write_stream,
-                mcp_server_instance.create_initialization_options(),
-                stateless=stateless_instance,
-            )
+            _global_status["active_sse_connections"] += 1
+            try:
+                await mcp_server_instance.run(
+                    read_stream,
+                    write_stream,
+                    mcp_server_instance.create_initialization_options(),
+                    stateless=stateless_instance,
+                )
+            finally:
+                _global_status["active_sse_connections"] -= 1
         return Response()
 
     async def handle_streamable_http_instance(scope: Scope, receive: Receive, send: Send) -> None:


### PR DESCRIPTION
## What

Adds an `active_sse_connections` counter to the `/status` payload: incremented when an SSE session enters `mcp_server_instance.run()`, decremented in a `finally` when the connection ends.

```json
{"api_last_activity": "...", "active_sse_connections": 1, "server_instances": {...}}
```

## Why

`api_last_activity` is refreshed on the SSE path only at connect time: `_update_global_activity()` runs once in `handle_sse_instance` before `run()` blocks for the connection's entire life, and the `/messages/` mount (where client-to-server POSTs land) never touches it. So a long-lived SSE session that is actively working reads as idle-since-connect.

That makes `/status` unable to answer the operational question "is anyone attached right now?" — which matters because restarting the proxy severs live SSE sessions with no re-handshake. A connection count answers it directly and cheaply where the timestamp cannot. (Streamable HTTP is unaffected: it already refreshes the timestamp per request.)

## Scope

Minimal by intent: one new field, increment/decrement around the existing SSE `run()` call, no behavior change to any transport. The single-threaded asyncio event loop makes the bare `+=`/`-=` safe without a lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
