### PR TITLE
fix: re-initialize upstream session after HTTP 404

### DIFF
--- a/src/mcp_proxy/reconnecting_session.py
+++ b/src/mcp_proxy/reconnecting_session.py
@@ -1,0 +1,169 @@
+"""Client session wrapper that rebuilds the upstream session when the remote drops it.
+
+When a streamable HTTP server restarts, it answers subsequent requests with HTTP 404. The MCP
+SDK turns that into an ``McpError`` carrying ``ErrorData(code=32600, message="Session
+terminated")`` and keeps the now stale ``mcp-session-id``, so every later call fails the same
+way. This wrapper detects that error, rebuilds the upstream connection and retries the call once.
+"""
+
+import logging
+import typing as t
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from types import TracebackType
+
+import anyio
+from mcp import types
+from mcp.client.session import ClientSession
+from mcp.shared.exceptions import McpError
+
+if t.TYPE_CHECKING:
+    from anyio.abc import TaskGroup
+    from typing_extensions import Self
+
+logger = logging.getLogger(__name__)
+
+SessionFactory = t.Callable[[], AbstractAsyncContextManager[ClientSession]]
+
+SESSION_TERMINATED_ERROR_CODE = 32600
+"""Code the SDK reports when the remote no longer knows the session (HTTP 404 mid-session)."""
+
+_NOT_CONNECTED = "Upstream session is not connected"
+
+
+def _is_session_lost(exc: BaseException) -> bool:
+    """Report whether the exception means the upstream session no longer exists."""
+    return isinstance(exc, McpError) and exc.error.code == SESSION_TERMINATED_ERROR_CODE
+
+
+@dataclass
+class _Connection:
+    """State of a single upstream connection, owned by one supervisor task."""
+
+    ready: anyio.Event
+    closing: anyio.Event
+    session: ClientSession | None = None
+    initialize_result: types.InitializeResult | None = None
+    error: BaseException | None = None
+
+
+class ReconnectingClientSession:
+    """Duck-typed ``ClientSession`` that re-initializes the upstream session when it is lost.
+
+    Every attribute other than the ones defined here is forwarded to the live upstream session.
+    A connection is entered and exited inside a dedicated supervisor task, because anyio cancel
+    scopes are bound to the task that created them while the low-level server dispatches every
+    request in its own task.
+    """
+
+    def __init__(self, connect: SessionFactory) -> None:
+        """Store the factory used to open each upstream connection."""
+        self._connect = connect
+        self._connection: _Connection | None = None
+        self._task_group: TaskGroup | None = None
+        self._lock: anyio.Lock | None = None
+
+    async def __aenter__(self) -> "Self":
+        """Start the supervisor task group and open the first upstream connection."""
+        self._lock = anyio.Lock()
+        task_group = anyio.create_task_group()
+        await task_group.__aenter__()
+        self._task_group = task_group
+        try:
+            await self._reconnect(None)
+        except BaseException:
+            self._task_group = None
+            await task_group.__aexit__(None, None, None)
+            raise
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Close the live connection, then wind down the supervisor task group."""
+        connection, self._connection = self._connection, None
+        if connection is not None:
+            connection.closing.set()
+        task_group, self._task_group = self._task_group, None
+        if task_group is None:
+            return None
+        return await task_group.__aexit__(exc_type, exc_value, traceback)
+
+    async def initialize(self) -> types.InitializeResult:
+        """Return the handshake result captured when the connection was opened.
+
+        Defining this method shadows :meth:`__getattr__`, so ``create_proxy_server`` does not
+        send a second ``initialize`` request over an already initialized session.
+        """
+        connection = self._connection
+        if connection is None or connection.initialize_result is None:
+            raise RuntimeError(_NOT_CONNECTED)
+        return connection.initialize_result
+
+    def __getattr__(self, name: str) -> t.Callable[..., t.Awaitable[t.Any]]:
+        """Forward a session method, retrying once if the upstream session was lost."""
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        async def call(*args: t.Any, **kwargs: t.Any) -> t.Any:  # noqa: ANN401
+            session = await self._acquire_session()
+            try:
+                return await getattr(session, name)(*args, **kwargs)
+            except McpError as exc:
+                if not _is_session_lost(exc):
+                    raise
+                logger.warning("Upstream session lost; re-initializing")
+            await self._reconnect(session)
+            retry_session = await self._acquire_session()
+            return await getattr(retry_session, name)(*args, **kwargs)
+
+        return call
+
+    async def _acquire_session(self) -> ClientSession:
+        """Return the live upstream session, opening one if an earlier attempt failed."""
+        connection = self._connection
+        if connection is not None and connection.session is not None:
+            return connection.session
+        await self._reconnect(None)
+        connection = self._connection
+        if connection is None or connection.session is None:
+            raise RuntimeError(_NOT_CONNECTED)
+        return connection.session
+
+    async def _reconnect(self, stale_session: ClientSession | None) -> None:
+        """Replace the connection owning ``stale_session``, at most once per outage."""
+        if self._lock is None:
+            raise RuntimeError(_NOT_CONNECTED)
+        async with self._lock:
+            current = self._connection
+            if current is not None and current.session is not stale_session:
+                return
+            self._connection = None
+            if current is not None:
+                current.closing.set()
+            if self._task_group is None:
+                raise RuntimeError(_NOT_CONNECTED)
+            connection = _Connection(ready=anyio.Event(), closing=anyio.Event())
+            self._task_group.start_soon(self._run_connection, connection)
+            await connection.ready.wait()
+            if connection.error is not None:
+                raise connection.error
+            self._connection = connection
+
+    async def _run_connection(self, connection: _Connection) -> None:
+        """Own one upstream connection for its whole lifetime, inside a single task."""
+        try:
+            async with self._connect() as session:
+                connection.initialize_result = await session.initialize()
+                connection.session = session
+                connection.ready.set()
+                await connection.closing.wait()
+        except Exception as exc:  # noqa: BLE001 - a dead connection must not kill the proxy
+            if connection.ready.is_set():
+                logger.debug("Upstream connection ended: %s", exc)
+            else:
+                connection.error = exc
+                connection.ready.set()

--- a/src/mcp_proxy/streamablehttp_client.py
+++ b/src/mcp_proxy/streamablehttp_client.py
@@ -1,7 +1,9 @@
 """Create a local server that proxies requests to a remote server over SSE."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from functools import partial
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from mcp.client.session import ClientSession
@@ -10,6 +12,7 @@ from mcp.server.stdio import stdio_server
 
 from .httpx_client import custom_httpx_client
 from .proxy_server import create_proxy_server
+from .reconnecting_session import ReconnectingClientSession
 
 
 async def run_streamablehttp_client(
@@ -27,16 +30,23 @@ async def run_streamablehttp_client(
         verify_ssl: Control SSL verification. Use False to disable
             or a path to a certificate bundle.
     """
-    async with (
-        streamablehttp_client(
-            url=url,
-            headers=headers,
-            auth=auth,
-            httpx_client_factory=partial(custom_httpx_client, verify_ssl=verify_ssl),
-        ) as (read, write, _),
-        ClientSession(read, write) as session,
-    ):
-        app = await create_proxy_server(session)
+
+    @asynccontextmanager
+    async def connect() -> AsyncIterator[ClientSession]:
+        async with (
+            streamablehttp_client(
+                url=url,
+                headers=headers,
+                auth=auth,
+                httpx_client_factory=partial(custom_httpx_client, verify_ssl=verify_ssl),
+            ) as (read, write, _),
+            ClientSession(read, write) as session,
+        ):
+            yield session
+
+    async with ReconnectingClientSession(connect) as session:
+        # The wrapper forwards every ClientSession method it is given via __getattr__.
+        app = await create_proxy_server(cast("ClientSession", session))
         async with stdio_server() as (read_stream, write_stream):
             await app.run(
                 read_stream,

--- a/tests/test_reconnecting_session.py
+++ b/tests/test_reconnecting_session.py
@@ -1,0 +1,377 @@
+"""Tests for the reconnecting client session wrapper.
+
+The wrapper is exercised against a scriptable fake upstream for the unit cases, and once
+end-to-end through a real ``create_proxy_server`` so that the anyio task ownership rules are
+verified against real task groups.
+"""
+
+import typing as t
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+
+import anyio
+import pytest
+from mcp import types
+from mcp.client.session import ClientSession
+from mcp.server import Server
+from mcp.shared.exceptions import McpError
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcp_proxy.proxy_server import create_proxy_server
+from mcp_proxy.reconnecting_session import (
+    SESSION_TERMINATED_ERROR_CODE,
+    ReconnectingClientSession,
+    SessionFactory,
+)
+
+TOOL_INPUT_SCHEMA = {"type": "object", "properties": {"input1": {"type": "string"}}}
+
+OK = "ok"
+PROGRESS_ID = "progress-1"
+
+ONE_CONNECT = 1
+TWO_CONNECTS = 2
+THREE_CONNECTS = 3
+CONCURRENT_CALLERS = 5
+
+# A connection that is never closed deadlocks the wrapper's teardown instead of failing an
+# assertion, so every test that opens a wrapper runs under a deadline.
+LIFECYCLE_TIMEOUT = 5
+
+INITIALIZE_RESULT = types.InitializeResult(
+    protocolVersion=types.LATEST_PROTOCOL_VERSION,
+    capabilities=types.ServerCapabilities(tools=types.ToolsCapability()),
+    serverInfo=types.Implementation(name="fake-upstream", version="1.0.0"),
+)
+
+
+def session_lost() -> McpError:
+    """Return the error the SDK raises once the remote has forgotten the session."""
+    return McpError(
+        types.ErrorData(code=SESSION_TERMINATED_ERROR_CODE, message="Session terminated"),
+    )
+
+
+class FakeSession:
+    """Stand-in for ``ClientSession`` whose method results are scripted per connection."""
+
+    def __init__(self, upstream: "FakeUpstream", script: dict[str, list[object]]) -> None:
+        """Bind the session to its upstream and to the script for this connection."""
+        self.upstream = upstream
+        self.script = script
+        self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    async def initialize(self) -> types.InitializeResult:
+        """Record a handshake and return a fixed initialization result."""
+        self.upstream.handshakes += 1
+        return INITIALIZE_RESULT
+
+    def __getattr__(self, name: str) -> Callable[..., Awaitable[object]]:
+        """Return a coroutine function serving the next scripted outcome for ``name``."""
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        async def call(*args: object, **kwargs: object) -> object:
+            self.calls.append((name, args, kwargs))
+            outcomes = self.script.get(name)
+            if outcomes:
+                outcome = outcomes.pop(0)
+                if isinstance(outcome, BaseException):
+                    raise outcome
+                return outcome
+            return OK
+
+        return call
+
+
+class FakeUpstream:
+    """Session factory that records connection lifecycles and scripts each connection."""
+
+    def __init__(
+        self,
+        scripts: list[dict[str, list[object]]] | None = None,
+        connect_errors: dict[int, BaseException] | None = None,
+        exit_errors: dict[int, BaseException] | None = None,
+    ) -> None:
+        """Configure the per-connection scripts and the connections that must fail."""
+        self.scripts = scripts or []
+        self.connect_errors = connect_errors or {}
+        self.exit_errors = exit_errors or {}
+        self.connects = 0
+        self.exits = 0
+        self.handshakes = 0
+        self.sessions: list[FakeSession] = []
+        self.closed: list[anyio.Event] = []
+
+    @asynccontextmanager
+    async def connect(self) -> AsyncIterator[ClientSession]:
+        """Open one scripted connection and count its entry and its exit."""
+        index = self.connects
+        self.connects += 1
+        error = self.connect_errors.get(index)
+        if error is not None:
+            raise error
+        script = self.scripts[index] if index < len(self.scripts) else {}
+        session = FakeSession(self, script)
+        self.sessions.append(session)
+        closed = anyio.Event()
+        self.closed.append(closed)
+        try:
+            yield t.cast("ClientSession", session)
+        finally:
+            self.exits += 1
+            closed.set()
+            exit_error = self.exit_errors.get(index)
+            if exit_error is not None:
+                raise exit_error
+
+
+@asynccontextmanager
+async def open_wrapper(connect: SessionFactory) -> AsyncIterator[ReconnectingClientSession]:
+    """Open a wrapper under a deadline so a leaked connection fails instead of hanging."""
+    with anyio.fail_after(LIFECYCLE_TIMEOUT):
+        async with ReconnectingClientSession(connect) as wrapper:
+            yield wrapper
+
+
+async def test_happy_path_uses_a_single_connection() -> None:
+    """A call that succeeds must not open a second connection."""
+    upstream = FakeUpstream()
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        assert await wrapper.list_tools() == OK
+
+    assert upstream.connects == ONE_CONNECT
+
+
+async def test_session_lost_rebuilds_and_retries() -> None:
+    """A session-terminated error must rebuild the connection and retry the call once."""
+    upstream = FakeUpstream(scripts=[{"list_tools": [session_lost()]}])
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        assert await wrapper.list_tools() == OK
+
+    assert upstream.connects == TWO_CONNECTS
+    assert upstream.sessions[0] is not upstream.sessions[1]
+    assert [name for name, _, _ in upstream.sessions[1].calls] == ["list_tools"]
+
+
+async def test_other_mcp_errors_propagate_unchanged() -> None:
+    """An ordinary protocol error must not trigger a rebuild."""
+    error = McpError(types.ErrorData(code=-32602, message="Invalid params"))
+    upstream = FakeUpstream(scripts=[{"list_tools": [error]}])
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        with pytest.raises(McpError) as exc_info:
+            await wrapper.list_tools()
+
+    assert exc_info.value is error
+    assert upstream.connects == ONE_CONNECT
+
+
+async def test_unexpected_errors_propagate_unchanged() -> None:
+    """A genuine tool failure must reach the caller instead of being retried."""
+    error = ValueError("tool exploded")
+    upstream = FakeUpstream(scripts=[{"call_tool": [error]}])
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        with pytest.raises(ValueError, match="tool exploded"):
+            await wrapper.call_tool("tool", {})
+
+    assert upstream.connects == ONE_CONNECT
+
+
+async def test_two_consecutive_session_losses_propagate() -> None:
+    """The wrapper retries once; a second failure must surface rather than spin."""
+    upstream = FakeUpstream(
+        scripts=[{"list_tools": [session_lost()]}, {"list_tools": [session_lost()]}],
+    )
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        with pytest.raises(McpError, match="Session terminated"):
+            await wrapper.list_tools()
+
+    assert upstream.connects == TWO_CONNECTS
+
+
+async def test_initialize_returns_the_cached_handshake() -> None:
+    """``initialize`` must reuse the handshake performed while opening the connection."""
+    upstream = FakeUpstream()
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        first = await wrapper.initialize()
+        second = await wrapper.initialize()
+
+    assert first is INITIALIZE_RESULT
+    assert second is INITIALIZE_RESULT
+    assert upstream.handshakes == ONE_CONNECT
+
+
+async def test_concurrent_callers_rebuild_once() -> None:
+    """Several handlers hitting the same outage must share one rebuild."""
+    upstream = FakeUpstream(scripts=[{"list_tools": [session_lost()] * CONCURRENT_CALLERS}])
+    results: list[object] = []
+
+    async with open_wrapper(upstream.connect) as wrapper:
+
+        async def call() -> None:
+            results.append(await wrapper.list_tools())
+
+        async with anyio.create_task_group() as task_group:
+            for _ in range(CONCURRENT_CALLERS):
+                task_group.start_soon(call)
+
+    assert results == [OK] * CONCURRENT_CALLERS
+    assert upstream.connects == TWO_CONNECTS
+
+
+async def test_failed_rebuild_propagates_and_is_not_fatal() -> None:
+    """A rebuild that cannot connect must raise, and must not poison later calls."""
+    upstream = FakeUpstream(
+        scripts=[{"list_tools": [session_lost()]}],
+        connect_errors={1: RuntimeError("upstream unreachable")},
+    )
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        with pytest.raises(RuntimeError, match="upstream unreachable"):
+            await wrapper.list_tools()
+        assert await wrapper.list_tools() == OK
+
+    assert upstream.connects == THREE_CONNECTS
+
+
+async def test_old_connection_is_closed_on_rebuild() -> None:
+    """The connection that lost its session must be torn down, not leaked."""
+    upstream = FakeUpstream(scripts=[{"list_tools": [session_lost()]}])
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        await wrapper.list_tools()
+        await upstream.closed[0].wait()
+        assert upstream.exits == ONE_CONNECT
+
+    assert upstream.exits == TWO_CONNECTS
+
+
+async def test_clean_shutdown_closes_every_connection() -> None:
+    """Leaving the wrapper must close as many connections as it opened."""
+    upstream = FakeUpstream(scripts=[{"list_tools": [session_lost()]}])
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        await wrapper.list_tools()
+
+    assert upstream.exits == upstream.connects
+
+
+async def test_keyword_arguments_survive_a_rebuild() -> None:
+    """Retried calls must be replayed with their positional and keyword arguments."""
+    upstream = FakeUpstream(scripts=[{"call_tool": [session_lost()]}])
+
+    async def progress_callback(progress: float, total: float | None, message: str | None) -> None:
+        """Ignore progress updates; only its identity matters for this test."""
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        assert (
+            await wrapper.call_tool(
+                "tool",
+                {"input1": "value"},
+                meta={"progressToken": "token"},
+                progress_callback=progress_callback,
+            )
+            == OK
+        )
+
+    name, args, kwargs = upstream.sessions[1].calls[0]
+    assert name == "call_tool"
+    assert args == ("tool", {"input1": "value"})
+    assert kwargs == {"meta": {"progressToken": "token"}, "progress_callback": progress_callback}
+
+
+async def test_notifications_forward_without_a_result() -> None:
+    """Methods that return nothing must be forwarded like any other."""
+    upstream = FakeUpstream(scripts=[{"send_progress_notification": [None]}])
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        result = await wrapper.send_progress_notification(
+            progress_token=PROGRESS_ID,
+            progress=1.0,
+        )
+
+    assert result is None
+
+
+async def test_initial_connect_failure_propagates() -> None:
+    """A first connection that cannot be opened must fail the wrapper's own startup."""
+    upstream = FakeUpstream(connect_errors={0: RuntimeError("upstream unreachable")})
+
+    with pytest.raises(RuntimeError, match="upstream unreachable"):
+        async with open_wrapper(upstream.connect):
+            pass  # pragma: no cover - the context manager never opens
+
+
+async def test_methods_before_entering_raise() -> None:
+    """Using the wrapper before it is entered must fail with a clear error."""
+    wrapper = ReconnectingClientSession(FakeUpstream().connect)
+
+    with pytest.raises(RuntimeError, match="not connected"):
+        await wrapper.initialize()
+    with pytest.raises(RuntimeError, match="not connected"):
+        await wrapper.list_tools()
+
+
+async def test_teardown_failures_do_not_kill_the_proxy() -> None:
+    """A connection that raises while closing must be logged, not propagated."""
+    upstream = FakeUpstream(
+        scripts=[{"list_tools": [session_lost()]}],
+        exit_errors={0: RuntimeError("socket already gone")},
+    )
+
+    async with open_wrapper(upstream.connect) as wrapper:
+        assert await wrapper.list_tools() == OK
+        await upstream.closed[0].wait()
+
+    assert upstream.connects == TWO_CONNECTS
+
+
+def test_private_attributes_are_not_forwarded() -> None:
+    """Dunder and private lookups must fail normally so introspection keeps working."""
+    wrapper = ReconnectingClientSession(FakeUpstream().connect)
+
+    with pytest.raises(AttributeError):
+        getattr(wrapper, "_not_a_session_method")  # noqa: B009 - the literal is the point
+
+
+async def test_rebuild_through_a_real_proxy_server() -> None:
+    """A rebuild triggered from a request handler must work with real anyio task groups."""
+    calls = 0
+    server: Server[object] = Server("flaky-server")
+
+    @server.list_tools()  # type: ignore[no-untyped-call,misc]
+    async def _() -> list[types.Tool]:
+        nonlocal calls
+        calls += 1
+        if calls == ONE_CONNECT:
+            raise session_lost()
+        return [
+            types.Tool(
+                name="tool",
+                description="tool-description",
+                inputSchema=TOOL_INPUT_SCHEMA,
+            ),
+        ]
+
+    connects = 0
+
+    @asynccontextmanager
+    async def connect() -> AsyncIterator[ClientSession]:
+        nonlocal connects
+        connects += 1
+        async with create_connected_server_and_client_session(server) as session:
+            yield session
+
+    async with open_wrapper(connect) as wrapper:
+        app = await create_proxy_server(t.cast("ClientSession", wrapper))
+        async with create_connected_server_and_client_session(app) as client:
+            result = await client.list_tools()
+
+    assert [tool.name for tool in result.tools] == ["tool"]
+    assert connects == TWO_CONNECTS


### PR DESCRIPTION
Closes #149.

## Problem

When a streamable HTTP server restarts, it forgets the session it issued. The proxy keeps sending the old `mcp-session-id`, the server answers `404 Not Found`, and the SDK surfaces that as:

```
ErrorData(code=32600, message="Session terminated")
```

The important detail is that the SDK does **not** tear the transport down. The stale `mcp-session-id` stays in place, so every subsequent call fails identically. The proxy process stays alive and healthy-looking while every downstream client is permanently broken until someone restarts it by hand.

Reproduced end-to-end against a real `mcp-proxy --transport streamablehttp` pointed at a uvicorn MCP server: kill the server, restart it, and the next `list_tools` fails with `McpError('Session terminated')` and never recovers.

## Why this belongs in mcp-proxy

The SDK pins the non-recovering behaviour deliberately - it has its own test asserting that a 404 mid-session surfaces as a session-terminated error, rather than reconnecting. The spec places session recovery on the client, and in this architecture mcp-proxy *is* the client. So the fix belongs here.

## Approach

New `ReconnectingClientSession` (`src/mcp_proxy/reconnecting_session.py`) wraps the upstream `ClientSession`:

- Forwards every session method through `__getattr__`.
- On a call that fails with code `32600`, rebuilds the upstream connection and retries that one call exactly once. A second consecutive failure propagates rather than spinning.
- Any other `McpError`, and any non-MCP exception, propagates untouched - a failing tool must not look like a lost session.
- Concurrent callers hitting the same outage share a single rebuild, guarded by a lock plus an identity check against the stale session.
- A rebuild that itself fails raises to that caller but does not poison the wrapper; the next call tries again.
- `initialize()` returns the handshake result cached when the connection was opened.

`run_streamablehttp_client` now builds its session through the wrapper. Its signature and observable behaviour are otherwise unchanged.

## The non-obvious part

The upstream connection is entered **and** exited inside one dedicated supervisor task, rather than being held open by whichever caller happened to trigger the rebuild.

This is required, not stylistic. anyio cancel scopes are task-bound, and `mcp/server/lowlevel/server.py::run` dispatches each request via `tg.start_soon(self._handle_message, ...)` - so every request handler runs in its own task. If the connection context manager were entered in one handler task and exited in another, anyio raises a cancel-scope-corruption error. The supervisor task owns the whole `async with`, and callers only ever hand it signals.

`tests/test_reconnecting_session.py::test_rebuild_through_a_real_proxy_server` pins this against a real `create_proxy_server` and real anyio task groups, not mocks.

## Typing

The wrapper is duck-typed and handed to `create_proxy_server` via `cast("ClientSession", ...)`. The alternative was a `Protocol` restating 13 `ClientSession` methods, which would need updating on every SDK release for no additional safety at the one call site involved. mypy runs strict and clean.

## Scope

Deliberately narrow, and smaller than the earlier attempts in #157 and #208:

- No new dependencies.
- No new CLI options and no configuration changes.
- No reconnect-manager abstraction, no telemetry, no README rewrite.
- One commit, three files.

## Non-goals

- **`sse_client.py` is untouched.** SSE has no session id to lose, so this failure mode does not apply.
- **stdio child-process death is not addressed** (#33, #208). That is a different failure with a different fix.
- #158 looks like the same root cause and is likely fixed by this too, but I have not reproduced it, so I am not claiming it.

## Testing

- 17 new tests; full suite 109 passed on every version in the CI matrix (3.10, 3.11, 3.12, 3.13, 3.14, 3.14t).
- ruff check and format clean at the pinned version; mypy strict clean at `--python-version` 3.10 and 3.13.
- Coverage 89.2% total, 92.7% on the new module, against the 83 gate.
- Verified end-to-end A/B against a real restarting server: on `main` the proxy exits 1 with one session id and `McpError('Session terminated')`; with this change it exits 0, opens a second session id, logs `Upstream session lost; re-initializing`, and the retried `call_tool` returns `isError=False`.

Tests that provoke connection-lifecycle regressions run under an `anyio.fail_after` deadline, so a future change that leaks a connection fails with a named test instead of deadlocking until the CI job timeout.
