### PR TITLE
fix: forward completion context arguments

### DIFF
--- a/src/mcp_proxy/proxy_server.py
+++ b/src/mcp_proxy/proxy_server.py
@@ -153,6 +153,7 @@ async def create_proxy_server(remote_app: ClientSession) -> server.Server[object
         result = await remote_app.complete(
             req.params.ref,
             req.params.argument.model_dump(),
+            context_arguments=req.params.context.arguments if req.params.context else None,
         )
         return types.ServerResult(result)
 

--- a/tests/test_proxy_server.py
+++ b/tests/test_proxy_server.py
@@ -197,7 +197,11 @@ def server_can_send_progress_notification(
 def server_can_complete(
     server: Server[object],
     complete_callback: Callable[
-        [types.PromptReference | types.ResourceReference, types.CompletionArgument],
+        [
+            types.PromptReference | types.ResourceTemplateReference,
+            types.CompletionArgument,
+            types.CompletionContext | None,
+        ],
         Awaitable[types.Completion | None],
     ],
 ) -> Server[object]:
@@ -205,11 +209,11 @@ def server_can_complete(
 
     @server.completion()  # type: ignore[no-untyped-call,misc]
     async def _completion(
-        reference: types.PromptReference | types.ResourceReference,
+        reference: types.PromptReference | types.ResourceTemplateReference,
         argument: types.CompletionArgument,
-        _context: object | None = None,
+        context: types.CompletionContext | None = None,
     ) -> types.Completion | None:
-        return await complete_callback(reference, argument)
+        return await complete_callback(reference, argument, context)
 
     return server
 
@@ -499,10 +503,20 @@ async def test_send_progress_notification(
 
 
 @pytest.mark.parametrize("complete_callback", [AsyncMock()])
+@pytest.mark.parametrize("context_arguments", [None, {}, {"owner": "example"}])
+@pytest.mark.parametrize(
+    "reference",
+    [
+        types.PromptReference(type="ref/prompt", name="name"),
+        types.ResourceTemplateReference(type="ref/resource", uri="repo://{owner}/{name}"),
+    ],
+)
 async def test_complete(
     session_generator: SessionContextManager,
     server_can_complete: Server[object],
     complete_callback: AsyncMock,
+    context_arguments: dict[str, str] | None,
+    reference: types.PromptReference | types.ResourceTemplateReference,
 ) -> None:
     """Test complete."""
     async with session_generator(server_can_complete) as session:
@@ -510,15 +524,19 @@ async def test_complete(
 
         complete_callback.return_value = None
         result = await session.complete(
-            types.PromptReference(type="ref/prompt", name="name"),
+            reference,
             argument={"name": "name", "value": "value"},
+            context_arguments=context_arguments,
         )
 
         assert result.completion.values == []
 
         complete_callback.assert_called_with(
-            types.PromptReference(type="ref/prompt", name="name"),
+            reference,
             types.CompletionArgument(name="name", value="value"),
+            types.CompletionContext(arguments=context_arguments)
+            if context_arguments is not None
+            else None,
         )
         complete_callback.reset_mock()
 


### PR DESCRIPTION
The proxy drops `context.arguments` from `completion/complete` requests. An upstream server therefore loses previously resolved arguments, such as the selected owner when completing a repository name. The same request works when the client connects directly.

Forward the incoming arguments through `ClientSession.complete(context_arguments=...)`. This is a one-line production change, preserving both omitted context and an explicitly empty argument mapping.

Extend the existing direct-versus-proxy completion test to cover prompt and resource-template references with absent, empty, and populated context. Before the fix, all direct cases pass and the four proxied cases with context fail; after the fix, all 12 combinations pass.

This follows the [MCP completion context specification](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion).

Validation with the locked dependencies on Python 3.12:
- `uv run --frozen coverage run -m pytest`: 102 passed.
- `uv run --frozen coverage report --fail-under 83`: 88.11%, above the CI threshold.
- `uv run --frozen mypy --python-version 3.13 src`: passed.
- All configured pre-commit hooks passed across the repository, including Ruff linting and formatting.
